### PR TITLE
Attempt to reformat and unify coding style of verification code

### DIFF
--- a/Isabelle/IMAP.thy
+++ b/Isabelle/IMAP.thy
@@ -26,10 +26,10 @@ where
 
 
 definition validState ::
-    "('a,'b) imap \<Rightarrow> bool"
+    "('a, 'b) imap \<Rightarrow> bool"
 where
-    "validState I = ((\<forall> (a,_) \<in> folderset I . (filesystem I) a \<noteq> None)
-    \<and> (\<forall> f . (filesystem I) f \<noteq> None \<longrightarrow> (\<exists> (a,_) \<in> folderset I . a = f)))"
+    "validState I = ((\<forall> (a, _) \<in> folderset I . (filesystem I) a \<noteq> None)
+    \<and> (\<forall> f . (filesystem I) f \<noteq> None \<longrightarrow> (\<exists> (a, _) \<in> folderset I . a = f)))"
 
 
 definition replaceMsg ::
@@ -41,9 +41,11 @@ where
 definition msgLookup ::
     "'a \<Rightarrow> 'b \<Rightarrow> ('a, 'b) imap \<Rightarrow> bool"
 where
-    "msgLookup f msg I = (case (filesystem I)(f) of
-    None \<Rightarrow> False |
-    Some msgset \<Rightarrow> msg \<in> msgset)"
+    "msgLookup f msg I = (
+    case (filesystem I)(f) of
+        None \<Rightarrow> False |
+        Some msgset \<Rightarrow> msg \<in> msgset
+    )"
 
 
 
@@ -55,7 +57,7 @@ where
 definition CREATE_atSource ::
     "'a \<Rightarrow> ('a, 'b) imap \<Rightarrow> bool"
 where
-    "CREATE_atSource f I = (\<nexists> n . (f,n) \<in> folderset I)"
+    "CREATE_atSource f I = (\<nexists> n . (f, n) \<in> folderset I)"
 
 definition CREATE_downstream ::
     "'a \<Rightarrow> nat \<Rightarrow> ('a, 'b) imap \<Rightarrow> ('a, 'b) imap"
@@ -72,7 +74,7 @@ where
 definition DELETE_atSource_pre ::
     "'a \<Rightarrow> ('a, 'b) imap \<Rightarrow> bool"
 where
-    "DELETE_atSource_pre e I = (\<exists> (a,_) \<in> folderset I . a = e)"
+    "DELETE_atSource_pre e I = (\<exists> (a, _) \<in> folderset I . a = e)"
 
 definition DELETE_downstream ::
     "'a \<Rightarrow> 'a orset \<Rightarrow> ('a, 'b) imap \<Rightarrow> ('a, 'b) imap"
@@ -83,7 +85,7 @@ where
 definition APPEND_atSource ::
     "'a \<Rightarrow> 'b \<Rightarrow> ('a, 'b) imap \<Rightarrow> bool"
 where
-    "APPEND_atSource f m I = (\<exists> (a,_) \<in> folderset I . a = f \<and> \<not> msgLookup f m I)"
+    "APPEND_atSource f m I = (\<exists> (a, _) \<in> folderset I . a = f \<and> \<not> msgLookup f m I)"
 
 definition APPEND_downstream ::
     "'a \<Rightarrow> 'b \<Rightarrow> ('a, 'b) imap \<Rightarrow> ('a, 'b) imap"
@@ -99,7 +101,7 @@ where
 definition STORE_atSource ::
     "'a \<Rightarrow> 'b \<Rightarrow> 'b \<Rightarrow> ('a, 'b) imap \<Rightarrow> bool"
 where
-    "STORE_atSource f msgold msgnew I = ((\<exists> (a,_) \<in> folderset I . a = f) \<and> msgLookup f msgold I \<and> \<not>(msgLookup f msgnew I))"
+    "STORE_atSource f msgold msgnew I = ((\<exists> (a, _) \<in> folderset I . a = f) \<and> msgLookup f msgold I \<and> \<not>(msgLookup f msgnew I))"
 
 definition STORE_downstream ::
     "'a \<Rightarrow> 'b \<Rightarrow> 'b \<Rightarrow> ('a, 'b) imap \<Rightarrow> ('a, 'b) imap"
@@ -115,7 +117,7 @@ where
 definition EXPUNGE_atSource ::
     "'a \<Rightarrow> 'b \<Rightarrow> ('a, 'b) imap \<Rightarrow> bool"
 where
-    "EXPUNGE_atSource f m I = ((\<exists> (a,_) \<in> folderset I . a = f) \<and> msgLookup f m I)"
+    "EXPUNGE_atSource f m I = ((\<exists> (a, _) \<in> folderset I . a = f) \<and> msgLookup f m I)"
 
 definition EXPUNGE_downstream ::
     "'a \<Rightarrow> 'b \<Rightarrow> ('a, 'b) imap \<Rightarrow> ('a, 'b) imap"
@@ -144,8 +146,15 @@ assumes
     validS: "validState I"
 shows "filesystem (APPEND_downstream f1 m1 I) f1 \<noteq> None"
 proof -
-    have "filesystem I f1 \<noteq> None" using O1pre validS unfolding validState_def APPEND_atSource_def by auto
-    thus ?thesis using validS O1pre unfolding APPEND_downstream_def validState_def APPEND_atSource_def by auto
+    have "filesystem I f1 \<noteq> None"
+    using O1pre validS
+    unfolding validState_def APPEND_atSource_def
+    by auto
+
+    thus ?thesis
+    using validS O1pre
+    unfolding APPEND_downstream_def validState_def APPEND_atSource_def
+    by auto
 qed
 
 
@@ -156,7 +165,9 @@ fixes
     m :: "'b"
 shows "folderset (APPEND_downstream f m I) = folderset I"
 proof -
-    show ?thesis unfolding APPEND_downstream_def by auto
+    show ?thesis
+    unfolding APPEND_downstream_def
+    by auto
 qed
 
 
@@ -169,7 +180,9 @@ assumes
     O1pre: " APPEND_atSource f1 m1 I" and
     validS: "validState I"
 shows "\<forall> f . f \<noteq> f1 \<longrightarrow> filesystem (APPEND_downstream f1 m1 I) f = filesystem I f"
-proof (simp add: APPEND_downstream_def option.case_eq_if)
+proof -
+    show ?thesis
+    by (simp add: APPEND_downstream_def option.case_eq_if)
 qed
 
 
@@ -179,7 +192,9 @@ fixes
     f :: "'a"
 shows "folderset (STORE_downstream f msgold msgnew I) = folderset I"
 proof -
-    show ?thesis unfolding STORE_downstream_def by auto
+    show ?thesis
+    unfolding STORE_downstream_def
+    by auto
 qed
 
 
@@ -189,7 +204,9 @@ fixes
     f1 :: "'a"
 shows "\<forall> f. f \<noteq> f1 \<longrightarrow> filesystem (STORE_downstream f1 msgold msgnew I) f = filesystem I f"
 proof -
-    show ?thesis unfolding STORE_downstream_def by (simp add: option.case_eq_if)
+    show ?thesis
+    unfolding STORE_downstream_def
+    by (simp add: option.case_eq_if)
 qed
 
 
@@ -203,7 +220,8 @@ assumes
     pre: "STORE_atSource f1 msgold msgnew I"
 shows "filesystem (STORE_downstream f1 msgold msgnew I) f1 \<noteq> None"
 proof -
-    show ?thesis using pre unfolding STORE_downstream_def STORE_atSource_def msgLookup_def
+    show ?thesis
+    using pre unfolding STORE_downstream_def STORE_atSource_def msgLookup_def
     by (metis fun_upd_same option.case_eq_if option.simps(3) snd_conv)
 qed
 
@@ -223,7 +241,10 @@ assumes
     validS: "validState I"
 shows "validState (CREATE_downstream e n I)"
 proof -
-    show ?thesis using validS unfolding CREATE_downstream_def add_def validState_def CREATE_atSource_def apply simp
+    show ?thesis
+    using validS
+    unfolding CREATE_downstream_def add_def validState_def CREATE_atSource_def
+    apply simp
     by (simp add: split_def)
 qed
 
@@ -238,14 +259,25 @@ assumes
     validS: "validState I"
 shows "validState (DELETE_downstream e1 R I)"
 proof -
-    have A1: "\<forall> (a,b) \<in> folderset I. a \<noteq> e1 \<longrightarrow> (a,b) \<in> folderset (DELETE_downstream e1 R I)"
-    using O1pre unfolding DELETE_downstream_def remove_downstream_def DELETE_atSource_def remove_atSource_def by auto
-    have "\<forall> (a,_) \<in> folderset (DELETE_downstream e1 R I). a \<noteq> e1" using O1pre
-    unfolding DELETE_downstream_def remove_downstream_def DELETE_atSource_def remove_atSource_def by auto
-    hence "(\<forall> (a,_) \<in> folderset (DELETE_downstream e1 R I) . (filesystem (DELETE_downstream e1 R I)) a \<noteq> None)" using validS
-    unfolding validState_def  DELETE_downstream_def remove_downstream_def DELETE_atSource_def remove_atSource_def by fastforce
-    thus ?thesis using validS A1 unfolding validState_def DELETE_atSource_def DELETE_downstream_def remove_atSource_def
-    remove_downstream_def apply simp by blast
+    have A1: "\<forall> (a, b) \<in> folderset I. a \<noteq> e1 \<longrightarrow> (a, b) \<in> folderset (DELETE_downstream e1 R I)"
+    using O1pre
+    unfolding DELETE_downstream_def remove_downstream_def DELETE_atSource_def remove_atSource_def
+    by auto
+
+    have "\<forall> (a, _) \<in> folderset (DELETE_downstream e1 R I). a \<noteq> e1"
+    using O1pre
+    unfolding DELETE_downstream_def remove_downstream_def DELETE_atSource_def remove_atSource_def
+    by auto
+
+    hence "(\<forall> (a, _) \<in> folderset (DELETE_downstream e1 R I) . (filesystem (DELETE_downstream e1 R I)) a \<noteq> None)" using validS
+    unfolding validState_def DELETE_downstream_def remove_downstream_def DELETE_atSource_def remove_atSource_def
+    by fastforce
+
+    thus ?thesis
+    using validS A1
+    unfolding validState_def DELETE_atSource_def DELETE_downstream_def remove_atSource_def remove_downstream_def
+    apply simp
+    by blast
 qed
 
 
@@ -259,10 +291,18 @@ assumes
     validS: "validState I"
 shows "validState (APPEND_downstream f1 m1 I)"
 proof -
-    have "folderset (APPEND_downstream f1 m1 I) = folderset I" unfolding APPEND_downstream_def by auto
-    hence "(\<forall>f. filesystem (APPEND_downstream f1 m1 I) f \<noteq> None \<longrightarrow> (\<exists>(a,_)\<in>folderset (APPEND_downstream f1 m1 I). a = f))"
-    using O1pre by (metis (no_types, lifting) APPEND_atSource_def append_filesystem case_prod_beta' validS validState_def)
-    thus ?thesis using O1pre validS unfolding validState_def APPEND_downstream_def apply simp
+    have "folderset (APPEND_downstream f1 m1 I) = folderset I"
+    unfolding APPEND_downstream_def
+    by auto
+
+    hence "(\<forall>f. filesystem (APPEND_downstream f1 m1 I) f \<noteq> None \<longrightarrow> (\<exists> (a, _) \<in>folderset (APPEND_downstream f1 m1 I). a = f))"
+    using O1pre
+    by (metis (no_types, lifting) APPEND_atSource_def append_filesystem case_prod_beta' validS validState_def)
+
+    thus ?thesis
+    using O1pre validS
+    unfolding validState_def APPEND_downstream_def
+    apply simp
     by (smt case_prodE fun_upd_apply old.prod.case option.case_eq_if)
 qed
 
@@ -278,7 +318,9 @@ assumes
     validS: "validState I"
 shows "validState (STORE_downstream f msgold msgnew I)"
 proof -
-    show ?thesis using O1pre validS unfolding STORE_downstream_def STORE_atSource_def msgLookup_def replaceMsg_def
+    show ?thesis
+    using O1pre validS
+    unfolding STORE_downstream_def STORE_atSource_def msgLookup_def replaceMsg_def
     by (simp add: case_prod_beta' fun_upd_same option.case_eq_if validState_def)
 qed
 
@@ -293,7 +335,9 @@ assumes
     validS: "validState I"
 shows "validState (EXPUNGE_downstream f m I)"
 proof -
-    show ?thesis using O1pre validS unfolding EXPUNGE_atSource_def EXPUNGE_downstream_def msgLookup_def validState_def
+    show ?thesis
+    using O1pre validS
+    unfolding EXPUNGE_atSource_def EXPUNGE_downstream_def msgLookup_def validState_def
     by (simp add: case_prod_beta' option.case_eq_if)
 qed
 
@@ -318,9 +362,9 @@ qed
 
 
 -- "Case 1"
-lemma commCREATE:
+lemma commCREATE_CREATE:
 fixes
-    I :: "('a,'b) imap" and
+    I :: "('a, 'b) imap" and
     e1 :: "'a" and
     e2 :: "'a" and
     n1 :: nat and
@@ -329,7 +373,10 @@ assumes
     n1neqn2: "n1 \<noteq> n2"
 shows "CREATE_downstream e1 n1 (CREATE_downstream e2 n2 I) = CREATE_downstream e2 n2 (CREATE_downstream e1 n1 I)"
 proof -
-    show ?thesis unfolding CREATE_downstream_def using commAdd n1neqn2 by fastforce
+    show ?thesis
+    unfolding CREATE_downstream_def
+    using commAdd n1neqn2
+    by fastforce
 qed
 
 
@@ -348,11 +395,20 @@ assumes
     lookupe1: "lookup e1 (folderset I)"
 shows "DELETE_downstream e1 R1 (CREATE_downstream e2 n I) = CREATE_downstream e2 n (DELETE_downstream e1 R1 I)"
 proof -
-    have fset: "folderset (DELETE_downstream e1 R1 (CREATE_downstream e2 n I)) = folderset (CREATE_downstream e2 n (DELETE_downstream e1 R1 I))" using O1R1 freshn unfolding DELETE_downstream_def CREATE_downstream_def fresh_def commAddRemove DELETE_atSource_def remove_atSource_def remove_downstream_def add_def by auto
+    have fset: "folderset (DELETE_downstream e1 R1 (CREATE_downstream e2 n I)) = folderset (CREATE_downstream e2 n (DELETE_downstream e1 R1 I))"
+    using O1R1 freshn
+    unfolding DELETE_downstream_def CREATE_downstream_def fresh_def commAddRemove DELETE_atSource_def remove_atSource_def remove_downstream_def add_def
+    by auto
 
-    have "filesystem (DELETE_downstream e1 R1 (CREATE_downstream e2 n I)) = filesystem (CREATE_downstream e2 n (DELETE_downstream e1 R1 I))" using O1R1 O2pre lookupe1 unfolding DELETE_downstream_def CREATE_downstream_def DELETE_atSource_def remove_atSource_def CREATE_atSource_def validState_def lookup_def by fastforce
+    have "filesystem (DELETE_downstream e1 R1 (CREATE_downstream e2 n I)) = filesystem (CREATE_downstream e2 n (DELETE_downstream e1 R1 I))"
+    using O1R1 O2pre lookupe1
+    unfolding DELETE_downstream_def CREATE_downstream_def DELETE_atSource_def remove_atSource_def CREATE_atSource_def validState_def lookup_def
+    by fastforce
 
-    thus ?thesis using fset unfolding DELETE_downstream_def by auto
+    thus ?thesis
+    using fset
+    unfolding DELETE_downstream_def
+    by auto
 qed
 
 
@@ -369,9 +425,15 @@ assumes
     O2pre: " CREATE_atSource e I"
 shows "APPEND_downstream f m (CREATE_downstream e n I) = CREATE_downstream e n (APPEND_downstream f m I)"
 proof -
-    have "filesystem(APPEND_downstream f m (CREATE_downstream e n I)) = filesystem(CREATE_downstream e n (APPEND_downstream f m I))" using O1pre O2pre unfolding APPEND_atSource_def APPEND_downstream_def CREATE_atSource_def CREATE_downstream_def by (smt case_prodE fun_upd_apply fun_upd_twist option.case_eq_if prod.sel(2))
+    have "filesystem(APPEND_downstream f m (CREATE_downstream e n I)) = filesystem(CREATE_downstream e n (APPEND_downstream f m I))"
+    using O1pre O2pre
+    unfolding APPEND_atSource_def APPEND_downstream_def CREATE_atSource_def CREATE_downstream_def
+    by (smt case_prodE fun_upd_apply fun_upd_twist option.case_eq_if prod.sel(2))
 
-    thus ?thesis using append_folderset[of f m I] unfolding APPEND_downstream_def CREATE_downstream_def by auto
+    thus ?thesis
+    using append_folderset[of f m I]
+    unfolding APPEND_downstream_def CREATE_downstream_def
+    by auto
 qed
 
 
@@ -389,11 +451,17 @@ assumes
     O2pre: " CREATE_atSource f2 I"
 shows "STORE_downstream f1 mo mn (CREATE_downstream f2 n I) = CREATE_downstream f2 n (STORE_downstream f1 mo mn I)"
 proof -
-    have A1: "folderset (STORE_downstream f1 mo mn (CREATE_downstream f2 n I)) = folderset (CREATE_downstream f2 n (STORE_downstream f1 mo mn I))" by (simp add: CREATE_downstream_def store_folderset)
+    have A1: "folderset (STORE_downstream f1 mo mn (CREATE_downstream f2 n I)) = folderset (CREATE_downstream f2 n (STORE_downstream f1 mo mn I))"
+    by (simp add: CREATE_downstream_def store_folderset)
 
-    have "filesystem (STORE_downstream f1 mo mn (CREATE_downstream f2 n I)) = filesystem (CREATE_downstream f2 n (STORE_downstream f1 mo mn I))" using O1pre O2pre unfolding STORE_downstream_def CREATE_downstream_def CREATE_atSource_def STORE_atSource_def by (smt case_prodE fun_upd_other fun_upd_twist option.case_eq_if snd_conv)
+    have "filesystem (STORE_downstream f1 mo mn (CREATE_downstream f2 n I)) = filesystem (CREATE_downstream f2 n (STORE_downstream f1 mo mn I))"
+    using O1pre O2pre
+    unfolding STORE_downstream_def CREATE_downstream_def CREATE_atSource_def STORE_atSource_def
+    by (smt case_prodE fun_upd_other fun_upd_twist option.case_eq_if snd_conv)
 
-    thus ?thesis using A1 by (simp add: prod.expand)
+    thus ?thesis
+    using A1
+    by (simp add: prod.expand)
 qed
 
 
@@ -410,16 +478,23 @@ assumes
     O2pre: " CREATE_atSource f2 I"
 shows "EXPUNGE_downstream f1 m (CREATE_downstream f2 n I) = CREATE_downstream f2 n (EXPUNGE_downstream f1 m I)"
 proof -
-    have A1: "folderset (EXPUNGE_downstream f1 m (CREATE_downstream f2 n I)) = folderset (CREATE_downstream f2 n (EXPUNGE_downstream f1 m I))" unfolding CREATE_downstream_def EXPUNGE_downstream_def by simp
+    have A1: "folderset (EXPUNGE_downstream f1 m (CREATE_downstream f2 n I)) = folderset (CREATE_downstream f2 n (EXPUNGE_downstream f1 m I))"
+    unfolding CREATE_downstream_def EXPUNGE_downstream_def
+    by simp
 
-    have "filesystem (EXPUNGE_downstream f1 m (CREATE_downstream f2 n I)) = filesystem (CREATE_downstream f2 n (EXPUNGE_downstream f1 m I))" using O1pre O2pre unfolding EXPUNGE_atSource_def EXPUNGE_downstream_def CREATE_atSource_def CREATE_downstream_def by (simp add: fun_upd_twist option.case_eq_if)
+    have "filesystem (EXPUNGE_downstream f1 m (CREATE_downstream f2 n I)) = filesystem (CREATE_downstream f2 n (EXPUNGE_downstream f1 m I))"
+    using O1pre O2pre
+    unfolding EXPUNGE_atSource_def EXPUNGE_downstream_def CREATE_atSource_def CREATE_downstream_def
+    by (simp add: fun_upd_twist option.case_eq_if)
 
-    thus ?thesis using A1 prod_eqI by blast
+    thus ?thesis
+    using A1 prod_eqI
+    by blast
 qed
 
 
 -- "Case 6"
-lemma commDELETE:
+lemma commDELETE_DELETE:
 fixes
     I :: "('a, 'b) imap" and
     R1 :: "'a orset" and
@@ -436,13 +511,20 @@ proof -
         assume a1: "R1 = {(a, b). (a, b) \<in> folderset I \<and> a = e1}"
         assume a2: "R2 = {(a, b). (a, b) \<in> folderset I \<and> a = e2}"
 
-        have f3: "\<forall>P a Pa Pb aa. (P \<noteq> remove_atSource (a::'a) Pa \<or> Pb \<noteq> remove_atSource aa Pa) \<or> remove_downstream Pb (remove_downstream P Pa) = remove_downstream P (remove_downstream Pb Pa)" by (meson commRemove)
+        have f3: "\<forall>P a Pa Pb aa. (P \<noteq> remove_atSource (a::'a) Pa \<or> Pb \<noteq> remove_atSource aa Pa) \<or> remove_downstream Pb (remove_downstream P Pa) = remove_downstream P (remove_downstream Pb Pa)"
+        by (meson commRemove)
 
-        have f4: "{(a, n). (a, n) \<in> folderset I \<and> a = e1} = remove_atSource e1 (folderset I)" using a1 by (simp add: DELETE_atSource_def O1R1)
+        have f4: "{(a, n). (a, n) \<in> folderset I \<and> a = e1} = remove_atSource e1 (folderset I)"
+        using a1
+        by (simp add: DELETE_atSource_def O1R1)
 
-        have "{(a, n). (a, n) \<in> folderset I \<and> a = e2} = remove_atSource e2 (folderset I)" using a2 by (simp add: DELETE_atSource_def O2R2)
+        have "{(a, n). (a, n) \<in> folderset I \<and> a = e2} = remove_atSource e2 (folderset I)"
+        using a2
+        by (simp add: DELETE_atSource_def O2R2)
 
-        then show "remove_downstream {(a, n). (a, n) \<in> folderset I \<and> a = e2} (remove_downstream {(a, n). (a, n) \<in> folderset I \<and> a = e1} (folderset I)) = remove_downstream {(a, n). (a, n) \<in> folderset I \<and> a = e1} (remove_downstream {(a, n). (a, n) \<in> folderset I \<and> a = e2} (folderset I)) \<and> (filesystem I)(e1 := None, e2 := None) = (filesystem I) (e2 := None, e1 := None)" using f4 f3 by auto
+        then show "remove_downstream {(a, n). (a, n) \<in> folderset I \<and> a = e2} (remove_downstream {(a, n). (a, n) \<in> folderset I \<and> a = e1} (folderset I)) = remove_downstream {(a, n). (a, n) \<in> folderset I \<and> a = e1} (remove_downstream {(a, n). (a, n) \<in> folderset I \<and> a = e2} (folderset I)) \<and> (filesystem I)(e1 := None, e2 := None) = (filesystem I) (e2 := None, e1 := None)"
+        using f4 f3
+        by auto
     qed
 qed
 
@@ -460,11 +542,18 @@ assumes
     O2pre: " R = DELETE_atSource e I"
 shows "APPEND_downstream f m (DELETE_downstream e R I) = DELETE_downstream e R (APPEND_downstream f m I)"
 proof -
-    have A1: "folderset(APPEND_downstream f m (DELETE_downstream e R I)) = folderset(DELETE_downstream e R (APPEND_downstream f m I))" unfolding DELETE_downstream_def by (simp add: append_folderset)
+    have A1: "folderset(APPEND_downstream f m (DELETE_downstream e R I)) = folderset(DELETE_downstream e R (APPEND_downstream f m I))"
+    unfolding DELETE_downstream_def
+    by (simp add: append_folderset)
 
-    have "filesystem(APPEND_downstream f m (DELETE_downstream e R I)) = filesystem(DELETE_downstream e R (APPEND_downstream f m I))" using O1pre O2pre unfolding APPEND_atSource_def APPEND_downstream_def DELETE_atSource_def DELETE_downstream_def by (simp add: fun_upd_twist option.case_eq_if)
+    have "filesystem(APPEND_downstream f m (DELETE_downstream e R I)) = filesystem(DELETE_downstream e R (APPEND_downstream f m I))"
+    using O1pre O2pre
+    unfolding APPEND_atSource_def APPEND_downstream_def DELETE_atSource_def DELETE_downstream_def
+    by (simp add: fun_upd_twist option.case_eq_if)
 
-    thus ?thesis using A1 prod_eqI by blast
+    thus ?thesis
+    using A1 prod_eqI
+    by blast
 qed
 
 
@@ -482,11 +571,17 @@ assumes
     O2pre: " R = DELETE_atSource f2 I"
 shows "STORE_downstream f1 mo mn (DELETE_downstream f2 R I) = DELETE_downstream f2 R (STORE_downstream f1 mo mn I)"
 proof -
-    have A1: "folderset (STORE_downstream f1 mo mn (DELETE_downstream f2 R I)) = folderset(DELETE_downstream f2 R (STORE_downstream f1 mo mn I))" by (simp add: DELETE_downstream_def store_folderset)
+    have A1: "folderset (STORE_downstream f1 mo mn (DELETE_downstream f2 R I)) = folderset(DELETE_downstream f2 R (STORE_downstream f1 mo mn I))"
+    by (simp add: DELETE_downstream_def store_folderset)
 
-    have "filesystem (STORE_downstream f1 mo mn (DELETE_downstream f2 R I)) = filesystem(DELETE_downstream f2 R (STORE_downstream f1 mo mn I))" using O1pre O2pre unfolding STORE_downstream_def DELETE_downstream_def DELETE_atSource_def STORE_atSource_def by (simp add: fun_upd_twist option.case_eq_if)
+    have "filesystem (STORE_downstream f1 mo mn (DELETE_downstream f2 R I)) = filesystem(DELETE_downstream f2 R (STORE_downstream f1 mo mn I))"
+    using O1pre O2pre
+    unfolding STORE_downstream_def DELETE_downstream_def DELETE_atSource_def STORE_atSource_def
+    by (simp add: fun_upd_twist option.case_eq_if)
 
-    thus ?thesis using A1 by (simp add: prod.expand)
+    thus ?thesis
+    using A1
+    by (simp add: prod.expand)
 qed
 
 
@@ -503,16 +598,23 @@ assumes
     O2pre: " R = DELETE_atSource f2 I"
 shows "EXPUNGE_downstream f1 m (DELETE_downstream f2 R I) = DELETE_downstream f2 R (EXPUNGE_downstream f1 m I)"
 proof -
-    have A1: "folderset(EXPUNGE_downstream f1 m (DELETE_downstream f2 R I)) = folderset (DELETE_downstream f2 R (EXPUNGE_downstream f1 m I))" unfolding DELETE_downstream_def EXPUNGE_downstream_def by simp
+    have A1: "folderset(EXPUNGE_downstream f1 m (DELETE_downstream f2 R I)) = folderset (DELETE_downstream f2 R (EXPUNGE_downstream f1 m I))"
+    unfolding DELETE_downstream_def EXPUNGE_downstream_def
+    by simp
 
-    have "filesystem(EXPUNGE_downstream f1 m (DELETE_downstream f2 R I)) = filesystem (DELETE_downstream f2 R (EXPUNGE_downstream f1 m I))" using O1pre O2pre unfolding EXPUNGE_atSource_def EXPUNGE_downstream_def DELETE_atSource_def DELETE_downstream_def msgLookup_def by (simp add: fun_upd_twist option.case_eq_if)
+    have "filesystem(EXPUNGE_downstream f1 m (DELETE_downstream f2 R I)) = filesystem (DELETE_downstream f2 R (EXPUNGE_downstream f1 m I))"
+    using O1pre O2pre
+    unfolding EXPUNGE_atSource_def EXPUNGE_downstream_def DELETE_atSource_def DELETE_downstream_def msgLookup_def
+    by (simp add: fun_upd_twist option.case_eq_if)
 
-    thus ?thesis using A1 prod_eqI by blast
+    thus ?thesis
+    using A1 prod_eqI
+    by blast
 qed
 
 
 -- "Case 10"
-lemma commAPPEND:
+lemma commAPPEND_APPEND:
 fixes
     I :: "('a, 'b) imap" and
     f1 :: "'a" and
@@ -525,11 +627,17 @@ assumes
     freshm: "m1 \<noteq> m2"
 shows "APPEND_downstream f1 m1 (APPEND_downstream f2 m2 I) = APPEND_downstream f2 m2 (APPEND_downstream f1 m1 I)"
 proof -
-    have A1: "folderset(APPEND_downstream f1 m1 (APPEND_downstream f2 m2 I)) = folderset(APPEND_downstream f2 m2 (APPEND_downstream f1 m1 I))" by (simp add: APPEND_downstream_def)
+    have A1: "folderset(APPEND_downstream f1 m1 (APPEND_downstream f2 m2 I)) = folderset(APPEND_downstream f2 m2 (APPEND_downstream f1 m1 I))"
+    by (simp add: APPEND_downstream_def)
 
-    have "filesystem(APPEND_downstream f1 m1 (APPEND_downstream f2 m2 I)) = filesystem(APPEND_downstream f2 m2 (APPEND_downstream f1 m1 I))" using O1pre O2pre freshm  unfolding APPEND_downstream_def APPEND_atSource_def msgLookup_def by (smt Un_insert_right fun_upd_twist fun_upd_upd insert_commute map_upd_Some_unfold option.case_eq_if option.collapse option.simps(3) snd_conv sup_bot.right_neutral)
+    have "filesystem(APPEND_downstream f1 m1 (APPEND_downstream f2 m2 I)) = filesystem(APPEND_downstream f2 m2 (APPEND_downstream f1 m1 I))"
+    using O1pre O2pre freshm
+    unfolding APPEND_downstream_def APPEND_atSource_def msgLookup_def
+    by (smt Un_insert_right fun_upd_twist fun_upd_upd insert_commute map_upd_Some_unfold option.case_eq_if option.collapse option.simps(3) snd_conv sup_bot.right_neutral)
 
-    thus ?thesis using A1 by (simp add: prod_eq_iff)
+    thus ?thesis
+    using A1
+    by (simp add: prod_eq_iff)
 qed
 
 
@@ -549,11 +657,17 @@ assumes
     freshmo: "m \<noteq> mo"
 shows "STORE_downstream f1 mo mn (APPEND_downstream f2 m I) = APPEND_downstream f2 m (STORE_downstream f1 mo mn I)"
 proof -
-    have A1: "folderset (STORE_downstream f1 mo mn (APPEND_downstream f2 m I)) = folderset (APPEND_downstream f2 m (STORE_downstream f1 mo mn I))" by (simp add: APPEND_downstream_def store_folderset)
+    have A1: "folderset (STORE_downstream f1 mo mn (APPEND_downstream f2 m I)) = folderset (APPEND_downstream f2 m (STORE_downstream f1 mo mn I))"
+    by (simp add: APPEND_downstream_def store_folderset)
 
-    have "filesystem (STORE_downstream f1 mo mn (APPEND_downstream f2 m I)) = filesystem(APPEND_downstream f2 m (STORE_downstream f1 mo mn I))" using O1pre O2pre freshmn freshmo unfolding STORE_downstream_def APPEND_downstream_def APPEND_atSource_def STORE_atSource_def replaceMsg_def by (smt Diff_insert0 Un_Diff Un_Diff_cancel2 Un_insert_right empty_iff fun_upd_twist fun_upd_upd insert_iff insert_is_Un map_upd_Some_unfold option.case_eq_if option.collapse option.simps(5) snd_conv sup_bot.right_neutral)
+    have "filesystem (STORE_downstream f1 mo mn (APPEND_downstream f2 m I)) = filesystem(APPEND_downstream f2 m (STORE_downstream f1 mo mn I))"
+    using O1pre O2pre freshmn freshmo
+    unfolding STORE_downstream_def APPEND_downstream_def APPEND_atSource_def STORE_atSource_def replaceMsg_def
+    by (smt Diff_insert0 Un_Diff Un_Diff_cancel2 Un_insert_right empty_iff fun_upd_twist fun_upd_upd insert_iff insert_is_Un map_upd_Some_unfold option.case_eq_if option.collapse option.simps(5) snd_conv sup_bot.right_neutral)
 
-    thus ?thesis using A1 by (simp add: prod.expand)
+    thus ?thesis
+    using A1
+    by (simp add: prod.expand)
 qed
 
 
@@ -570,16 +684,23 @@ assumes
     O2pre: "APPEND_atSource f2 m2 I"
 shows "EXPUNGE_downstream f1 m1 (APPEND_downstream f2 m2 I) = APPEND_downstream f2 m2 (EXPUNGE_downstream f1 m1 I)"
 proof -
-    have A1: "folderset (EXPUNGE_downstream f1 m1 (APPEND_downstream f2 m2 I)) = folderset (APPEND_downstream f2 m2 (EXPUNGE_downstream f1 m1 I))" unfolding EXPUNGE_downstream_def APPEND_downstream_def by simp
+    have A1: "folderset (EXPUNGE_downstream f1 m1 (APPEND_downstream f2 m2 I)) = folderset (APPEND_downstream f2 m2 (EXPUNGE_downstream f1 m1 I))"
+    unfolding EXPUNGE_downstream_def APPEND_downstream_def
+    by simp
 
-    have "filesystem (EXPUNGE_downstream f1 m1 (APPEND_downstream f2 m2 I)) = filesystem (APPEND_downstream f2 m2 (EXPUNGE_downstream f1 m1 I))" using O1pre O2pre unfolding EXPUNGE_downstream_def EXPUNGE_atSource_def APPEND_downstream_def APPEND_atSource_def by (smt Diff_empty Diff_insert0 Un_Diff case_prod_beta' fun_upd_apply fun_upd_twist fun_upd_upd insert_Diff insert_Diff1 map_upd_eqD1 mk_disjoint_insert msgLookup_def option.case_eq_if option.collapse option.simps(3) singletonI snd_conv)
+    have "filesystem (EXPUNGE_downstream f1 m1 (APPEND_downstream f2 m2 I)) = filesystem (APPEND_downstream f2 m2 (EXPUNGE_downstream f1 m1 I))"
+    using O1pre O2pre
+    unfolding EXPUNGE_downstream_def EXPUNGE_atSource_def APPEND_downstream_def APPEND_atSource_def
+    by (smt Diff_empty Diff_insert0 Un_Diff case_prod_beta' fun_upd_apply fun_upd_twist fun_upd_upd insert_Diff insert_Diff1 map_upd_eqD1 mk_disjoint_insert msgLookup_def option.case_eq_if option.collapse option.simps(3) singletonI snd_conv)
 
-    thus ?thesis using A1 prod_eqI by blast
+    thus ?thesis
+    using A1 prod_eqI
+    by blast
 qed
 
 
 -- "Case 13"
-lemma commSTORE:
+lemma commSTORE_STORE:
 fixes
     I :: "('a, 'b) imap" and
     f1 :: "'a" and
@@ -593,44 +714,90 @@ assumes
     O2pre: " STORE_atSource f2 mo2 mn2 I"
 shows "STORE_downstream f1 mo1 mn1 (STORE_downstream f2 mo2 mn2 I) = STORE_downstream f2 mo2 mn2 (STORE_downstream f1 mo1 mn1 I)"
 proof -
-    have A1: "folderset (STORE_downstream f1 mo1 mn1 (STORE_downstream f2 mo2 mn2 I)) = folderset(STORE_downstream f2 mo2 mn2 (STORE_downstream f1 mo1 mn1 I))" by (simp add: store_folderset)
+    have A1: "folderset (STORE_downstream f1 mo1 mn1 (STORE_downstream f2 mo2 mn2 I)) = folderset(STORE_downstream f2 mo2 mn2 (STORE_downstream f1 mo1 mn1 I))"
+    by (simp add: store_folderset)
 
-    have A5: "\<forall> f . f1 \<noteq> f2 \<longrightarrow> filesystem (STORE_downstream f1 mo1 mn1 (STORE_downstream f2 mo2 mn2 I)) f = filesystem(STORE_downstream f2 mo2 mn2 (STORE_downstream f1 mo1 mn1 I)) f" by (smt STORE_downstream_def fun_upd_twist option.case_eq_if snd_conv store_filesystem)
+    have A2: "\<forall> f . f1 \<noteq> f2 \<longrightarrow> filesystem (STORE_downstream f1 mo1 mn1 (STORE_downstream f2 mo2 mn2 I)) f = filesystem(STORE_downstream f2 mo2 mn2 (STORE_downstream f1 mo1 mn1 I)) f"
+    by (smt STORE_downstream_def fun_upd_twist option.case_eq_if snd_conv store_filesystem)
 
     have "f1 = f2 \<longrightarrow> filesystem (STORE_downstream f1 mo1 mn1 (STORE_downstream f2 mo2 mn2 I)) f1 = filesystem(STORE_downstream f2 mo2 mn2 (STORE_downstream f1 mo1 mn1 I)) f1"
     proof auto
         assume Ass: "f1 = f2"
-        hence "filesystem (STORE_downstream f1 mo1 mn1 (STORE_downstream f2 mo2 mn2 I)) f1 \<noteq> None" by (smt O2pre STORE_downstream_def fun_upd_eqD fun_upd_triv option.case_eq_if option.simps(3) snd_conv store_not_none)
 
-        hence "\<exists> y . filesystem (STORE_downstream f1 mo1 mn1 (STORE_downstream f2 mo2 mn2 I)) f1 = Some y" by simp
-        then obtain y where Ass4: "filesystem (STORE_downstream f1 mo1 mn1 (STORE_downstream f2 mo2 mn2 I)) f1 = Some y" by blast
+        hence "filesystem (STORE_downstream f1 mo1 mn1 (STORE_downstream f2 mo2 mn2 I)) f1 \<noteq> None"
+        by (smt O2pre STORE_downstream_def fun_upd_eqD fun_upd_triv option.case_eq_if option.simps(3) snd_conv store_not_none)
 
-        have "\<exists> S . filesystem (I) f1 = Some S" by (metis O2pre STORE_atSource_def \<open>f1 = f2\<close> case_optionE msgLookup_def)
-        then obtain S where Ass2: "(filesystem I) f1 = Some S" by blast
+        hence "\<exists> y . filesystem (STORE_downstream f1 mo1 mn1 (STORE_downstream f2 mo2 mn2 I)) f1 = Some y"
+        by simp
 
-        have "\<exists> x . filesystem (STORE_downstream f2 mo2 mn2 I) f1 = Some x" using Ass by (metis O2pre option.collapse store_not_none)
-        then obtain x where Ass3: "filesystem (STORE_downstream f2 mo2 mn2 I) f1 = Some x" by blast
+        then obtain y
+        where Ass4: "filesystem (STORE_downstream f1 mo1 mn1 (STORE_downstream f2 mo2 mn2 I)) f1 = Some y"
+        by blast
 
-        have "x = (S - {mo2}) \<union> {mn2}" using Ass Ass2 Ass3 unfolding STORE_downstream_def replaceMsg_def  by simp
-        hence Ass6: "y = (S - {mo1,mo2}) \<union> {mn1,mn2}" using Ass Ass2 Ass3 Ass4 O1pre O2pre unfolding STORE_downstream_def replaceMsg_def STORE_atSource_def by auto
+        have "\<exists> S . filesystem (I) f1 = Some S"
+        by (metis O2pre STORE_atSource_def \<open>f1 = f2\<close> case_optionE msgLookup_def)
 
-        have "\<exists> w . filesystem (STORE_downstream f1 mo1 mn1 I) f1 = Some w" using Ass by (metis O1pre option.collapse store_not_none)
-        then obtain w where Ass8: "filesystem (STORE_downstream f1 mo1 mn1 I) f1 = Some w" by blast
+        then obtain S
+        where Ass2: "(filesystem I) f1 = Some S"
+        by blast
 
-        hence Ass9: "w = (S - {mo1}) \<union> {mn1}" using Ass Ass2 unfolding STORE_downstream_def replaceMsg_def by simp
+        have "\<exists> x . filesystem (STORE_downstream f2 mo2 mn2 I) f1 = Some x"
+        using Ass
+        by (metis O2pre option.collapse store_not_none)
 
-        have "filesystem(STORE_downstream f2 mo2 mn2 (STORE_downstream f1 mo1 mn1 I)) f1 \<noteq> None" using O1pre unfolding STORE_downstream_def using Ass Ass2 by auto
+        then obtain x
+        where Ass3: "filesystem (STORE_downstream f2 mo2 mn2 I) f1 = Some x"
+        by blast
 
-        hence "\<exists> z . filesystem(STORE_downstream f2 mo2 mn2 (STORE_downstream f1 mo1 mn1 I)) f1 = Some z" by simp
+        have "x = (S - {mo2}) \<union> {mn2}"
+        using Ass Ass2 Ass3
+        unfolding STORE_downstream_def replaceMsg_def
+        by simp
 
-        then obtain z where Ass7: "filesystem(STORE_downstream f2 mo2 mn2 (STORE_downstream f1 mo1 mn1 I)) f1 = Some z" by blast
+        hence Ass6: "y = (S - {mo1,mo2}) \<union> {mn1,mn2}"
+        using Ass Ass2 Ass3 Ass4 O1pre O2pre
+        unfolding STORE_downstream_def replaceMsg_def STORE_atSource_def
+        by auto
 
-        hence "z = (S - {mo1,mo2}) \<union> {mn1,mn2}" using Ass Ass2 Ass9 Ass8 O1pre O2pre unfolding STORE_downstream_def replaceMsg_def STORE_atSource_def by auto
+        have "\<exists> w . filesystem (STORE_downstream f1 mo1 mn1 I) f1 = Some w"
+        using Ass
+        by (metis O1pre option.collapse store_not_none)
 
-        thus "filesystem (STORE_downstream f2 mo1 mn1 (STORE_downstream f2 mo2 mn2 I)) f2 = filesystem (STORE_downstream f2 mo2 mn2 (STORE_downstream f2 mo1 mn1 I)) f2" using Ass7 Ass4 Ass6 Ass by auto
+        then obtain w
+        where Ass8: "filesystem (STORE_downstream f1 mo1 mn1 I) f1 = Some w"
+        by blast
+
+        hence Ass9: "w = (S - {mo1}) \<union> {mn1}"
+        using Ass Ass2
+        unfolding STORE_downstream_def replaceMsg_def
+        by simp
+
+        have "filesystem(STORE_downstream f2 mo2 mn2 (STORE_downstream f1 mo1 mn1 I)) f1 \<noteq> None"
+        using O1pre
+        unfolding STORE_downstream_def
+        using Ass Ass2
+        by auto
+
+        hence "\<exists> z . filesystem(STORE_downstream f2 mo2 mn2 (STORE_downstream f1 mo1 mn1 I)) f1 = Some z"
+        by simp
+
+        then obtain z
+        where Ass7: "filesystem(STORE_downstream f2 mo2 mn2 (STORE_downstream f1 mo1 mn1 I)) f1 = Some z"
+        by blast
+
+        hence "z = (S - {mo1,mo2}) \<union> {mn1,mn2}"
+        using Ass Ass2 Ass9 Ass8 O1pre O2pre
+        unfolding STORE_downstream_def replaceMsg_def STORE_atSource_def
+        by auto
+
+        thus "filesystem (STORE_downstream f2 mo1 mn1 (STORE_downstream f2 mo2 mn2 I)) f2 = filesystem (STORE_downstream f2 mo2 mn2 (STORE_downstream f2 mo1 mn1 I)) f2"
+        using Ass7 Ass4 Ass6 Ass
+        by auto
     qed
 
-    thus ?thesis using A1 A5 by (smt O1pre O2pre STORE_downstream_def fun_upd_same fun_upd_twist fun_upd_upd option.case_eq_if prod_eqI snd_conv store_not_none)
+    thus ?thesis
+    using A1 A2
+    by (smt O1pre O2pre STORE_downstream_def fun_upd_same fun_upd_twist fun_upd_upd option.case_eq_if prod_eqI snd_conv store_not_none)
 qed
 
 
@@ -648,22 +815,38 @@ assumes
     O2pre: "STORE_atSource f2 mo mn I"
 shows "EXPUNGE_downstream f1 m1 (STORE_downstream f2 mo mn I) = STORE_downstream f2 mo mn (EXPUNGE_downstream f1 m1 I)"
 proof -
-    have A1: "folderset (EXPUNGE_downstream f1 m1 (STORE_downstream f2 mo mn I)) = folderset (STORE_downstream f2 mo mn (EXPUNGE_downstream f1 m1 I))" unfolding EXPUNGE_downstream_def STORE_downstream_def by simp
+    have A1: "folderset (EXPUNGE_downstream f1 m1 (STORE_downstream f2 mo mn I)) = folderset (STORE_downstream f2 mo mn (EXPUNGE_downstream f1 m1 I))"
+    unfolding EXPUNGE_downstream_def STORE_downstream_def
+    by simp
 
-    have A2: "\<forall> f . f1 \<noteq> f2 \<longrightarrow> filesystem (EXPUNGE_downstream f1 m1 (STORE_downstream f2 mo mn I)) f = filesystem (STORE_downstream f2 mo mn (EXPUNGE_downstream f1 m1 I)) f" using O1pre O2pre unfolding EXPUNGE_downstream_def EXPUNGE_atSource_def STORE_downstream_def STORE_atSource_def by (smt fun_upd_other fun_upd_twist option.case_eq_if snd_conv)
+    have A2: "\<forall> f . f1 \<noteq> f2 \<longrightarrow> filesystem (EXPUNGE_downstream f1 m1 (STORE_downstream f2 mo mn I)) f = filesystem (STORE_downstream f2 mo mn (EXPUNGE_downstream f1 m1 I)) f"
+    using O1pre O2pre
+    unfolding EXPUNGE_downstream_def EXPUNGE_atSource_def STORE_downstream_def STORE_atSource_def
+    by (smt fun_upd_other fun_upd_twist option.case_eq_if snd_conv)
 
-    have A3: "\<forall> f . (f1 = f2 \<and> f \<noteq> f1) \<longrightarrow> filesystem (EXPUNGE_downstream f1 m1 (STORE_downstream f2 mo mn I)) f = filesystem (STORE_downstream f2 mo mn (EXPUNGE_downstream f1 m1 I)) f" using O1pre O2pre unfolding EXPUNGE_downstream_def EXPUNGE_atSource_def STORE_downstream_def STORE_atSource_def by (smt fun_upd_other fun_upd_twist option.case_eq_if snd_conv)
+    have A3: "\<forall> f . (f1 = f2 \<and> f \<noteq> f1) \<longrightarrow> filesystem (EXPUNGE_downstream f1 m1 (STORE_downstream f2 mo mn I)) f = filesystem (STORE_downstream f2 mo mn (EXPUNGE_downstream f1 m1 I)) f"
+    using O1pre O2pre
+    unfolding EXPUNGE_downstream_def EXPUNGE_atSource_def STORE_downstream_def STORE_atSource_def
+    by (smt fun_upd_other fun_upd_twist option.case_eq_if snd_conv)
 
-    have "f1 = f2 \<longrightarrow> filesystem (EXPUNGE_downstream f1 m1 (STORE_downstream f2 mo mn I)) f1 = filesystem (STORE_downstream f2 mo mn (EXPUNGE_downstream f1 m1 I)) f1" using O1pre O2pre unfolding EXPUNGE_downstream_def EXPUNGE_atSource_def STORE_downstream_def STORE_atSource_def msgLookup_def replaceMsg_def by (smt Diff_empty Diff_insert Diff_insert0 Un_Diff empty_iff fun_upd_same insertE insert_commute map_upd_eqD1 option.case_eq_if option.collapse option.simps(3) snd_conv)
+    have "f1 = f2 \<longrightarrow> filesystem (EXPUNGE_downstream f1 m1 (STORE_downstream f2 mo mn I)) f1 = filesystem (STORE_downstream f2 mo mn (EXPUNGE_downstream f1 m1 I)) f1"
+    using O1pre O2pre
+    unfolding EXPUNGE_downstream_def EXPUNGE_atSource_def STORE_downstream_def STORE_atSource_def msgLookup_def replaceMsg_def
+    by (smt Diff_empty Diff_insert Diff_insert0 Un_Diff empty_iff fun_upd_same insertE insert_commute map_upd_eqD1 option.case_eq_if option.collapse option.simps(3) snd_conv)
 
-    hence "filesystem (EXPUNGE_downstream f1 m1 (STORE_downstream f2 mo mn I)) = filesystem (STORE_downstream f2 mo mn (EXPUNGE_downstream f1 m1 I))" using O1pre O2pre A2 A3 unfolding EXPUNGE_downstream_def EXPUNGE_atSource_def STORE_downstream_def STORE_atSource_def by fastforce
+    hence "filesystem (EXPUNGE_downstream f1 m1 (STORE_downstream f2 mo mn I)) = filesystem (STORE_downstream f2 mo mn (EXPUNGE_downstream f1 m1 I))"
+    using O1pre O2pre A2 A3
+    unfolding EXPUNGE_downstream_def EXPUNGE_atSource_def STORE_downstream_def STORE_atSource_def
+    by fastforce
 
-    thus ?thesis using A1 prod_eqI by blast
+    thus ?thesis
+    using A1 prod_eqI
+    by blast
 qed
 
 
 -- "Case 15"
-lemma commEXPUNGE:
+lemma commEXPUNGE_EXPUNGE:
 fixes
     I :: "('a, 'b) imap" and
     f1 :: "'a" and
@@ -675,11 +858,18 @@ assumes
     O2pre: " EXPUNGE_atSource f2 m2 I"
 shows "EXPUNGE_downstream f1 m1 (EXPUNGE_downstream f2 m2 I) = EXPUNGE_downstream f2 m2 (EXPUNGE_downstream f1 m1 I)"
 proof -
-    have A1: "folderset (EXPUNGE_downstream f1 m1 (EXPUNGE_downstream f2 m2 I)) = folderset (EXPUNGE_downstream f2 m2 (EXPUNGE_downstream f1 m1 I))" unfolding EXPUNGE_downstream_def EXPUNGE_atSource_def by simp
+    have A1: "folderset (EXPUNGE_downstream f1 m1 (EXPUNGE_downstream f2 m2 I)) = folderset (EXPUNGE_downstream f2 m2 (EXPUNGE_downstream f1 m1 I))"
+    unfolding EXPUNGE_downstream_def EXPUNGE_atSource_def
+    by simp
 
-    have "filesystem (EXPUNGE_downstream f1 m1 (EXPUNGE_downstream f2 m2 I)) = filesystem (EXPUNGE_downstream f2 m2 (EXPUNGE_downstream f1 m1 I))" using O1pre O2pre unfolding EXPUNGE_downstream_def EXPUNGE_atSource_def msgLookup_def by (smt Diff_insert fun_upd_twist fun_upd_upd insert_commute map_upd_Some_unfold option.case_eq_if option.collapse option.simps(3) snd_conv)
+    have "filesystem (EXPUNGE_downstream f1 m1 (EXPUNGE_downstream f2 m2 I)) = filesystem (EXPUNGE_downstream f2 m2 (EXPUNGE_downstream f1 m1 I))"
+    using O1pre O2pre
+    unfolding EXPUNGE_downstream_def EXPUNGE_atSource_def msgLookup_def
+    by (smt Diff_insert fun_upd_twist fun_upd_upd insert_commute map_upd_Some_unfold option.case_eq_if option.collapse option.simps(3) snd_conv)
 
-    thus ?thesis using A1 by (simp add: prod_eqI)
+    thus ?thesis
+    using A1
+    by (simp add: prod_eqI)
 qed
 
 

--- a/Isabelle/IMAP.thy
+++ b/Isabelle/IMAP.thy
@@ -1,657 +1,687 @@
 theory IMAP
 imports ORSet
-	
+
 begin
-	
--- "Type defeinition: 'a is the set of all foldernames, 'b is the set of all messagenames"
+
+
+
+-- "#############################"
+-- "### Definitions & Helpers ###"
+-- "#############################"
+
+
+-- "Type definition: 'a is the set of all folder names, 'b is the set of all message names"
 type_synonym ('a, 'b) imap = "'a orset \<times> ('a \<rightharpoonup> 'b set)"
 
+
 abbreviation folderset ::
-  "('a, 'b) imap \<Rightarrow> 'a orset" 
+    "('a, 'b) imap \<Rightarrow> 'a orset"
 where
-  "folderset I \<equiv> fst I"
-  
+    "folderset I \<equiv> fst I"
+
 abbreviation filesystem ::
-  "('a, 'b) imap \<Rightarrow> ('a \<rightharpoonup> 'b set)"
+    "('a, 'b) imap \<Rightarrow> ('a \<rightharpoonup> 'b set)"
 where
-  "filesystem I \<equiv> snd I"
+    "filesystem I \<equiv> snd I"
+
 
 definition validState ::
-	"('a,'b) imap \<Rightarrow> bool"
-	where
-	"validState I = ((\<forall> (a,_) \<in> folderset I . (filesystem I) a \<noteq> None)
-	\<and> (\<forall> f . (filesystem I) f \<noteq> None \<longrightarrow> (\<exists> (a,_) \<in> folderset I . a = f)))"
-	
-definition replaceMsg ::
-	"'b \<Rightarrow> 'b \<Rightarrow> 'b set \<Rightarrow> 'b set"
+    "('a,'b) imap \<Rightarrow> bool"
 where
-	"replaceMsg msgold msgnew S = (S - {msgold}) \<union> {msgnew}"
+    "validState I = ((\<forall> (a,_) \<in> folderset I . (filesystem I) a \<noteq> None)
+    \<and> (\<forall> f . (filesystem I) f \<noteq> None \<longrightarrow> (\<exists> (a,_) \<in> folderset I . a = f)))"
+
+
+definition replaceMsg ::
+    "'b \<Rightarrow> 'b \<Rightarrow> 'b set \<Rightarrow> 'b set"
+where
+    "replaceMsg msgold msgnew S = (S - {msgold}) \<union> {msgnew}"
+
 
 definition msgLookup ::
-  "'a \<Rightarrow> 'b \<Rightarrow> ('a, 'b) imap \<Rightarrow> bool"
+    "'a \<Rightarrow> 'b \<Rightarrow> ('a, 'b) imap \<Rightarrow> bool"
 where
-  "msgLookup f msg I = (case (filesystem I)(f) of 
-			None \<Rightarrow> False | 
-			Some msgset \<Rightarrow> msg \<in> msgset)"
+    "msgLookup f msg I = (case (filesystem I)(f) of
+    None \<Rightarrow> False |
+    Some msgset \<Rightarrow> msg \<in> msgset)"
 
--- "######### BEGIN OPERATIONS ##########"
+
+
+-- "#######################"
+-- "### IMAP Operations ###"
+-- "#######################"
+
 
 definition CREATE_atSource ::
-	"'a \<Rightarrow> ('a, 'b) imap \<Rightarrow> bool"
+    "'a \<Rightarrow> ('a, 'b) imap \<Rightarrow> bool"
 where
-	"CREATE_atSource f I = (\<nexists> n . (f,n) \<in> folderset I)"
-  
+    "CREATE_atSource f I = (\<nexists> n . (f,n) \<in> folderset I)"
+
 definition CREATE_downstream ::
-	"'a \<Rightarrow> nat \<Rightarrow> ('a, 'b) imap \<Rightarrow> ('a, 'b) imap"
+    "'a \<Rightarrow> nat \<Rightarrow> ('a, 'b) imap \<Rightarrow> ('a, 'b) imap"
 where
-	"CREATE_downstream f n I = (add f n (folderset I), (filesystem I)(f := Some {}))"
+    "CREATE_downstream f n I = (add f n (folderset I), (filesystem I)(f := Some {}))"
+
 
 definition DELETE_atSource ::
-	"'a \<Rightarrow> ('a, 'b) imap \<Rightarrow> 'a orset"
-	where
-	"DELETE_atSource e I = remove_atSource e (folderset I)"
+    "'a \<Rightarrow> ('a, 'b) imap \<Rightarrow> 'a orset"
+where
+    "DELETE_atSource e I = remove_atSource e (folderset I)"
 
 -- "unused"
 definition DELETE_atSource_pre ::
-	"'a \<Rightarrow> ('a, 'b) imap \<Rightarrow> bool"
-	where
-	"DELETE_atSource_pre e I = (\<exists> (a,_) \<in> folderset I . a = e)"
+    "'a \<Rightarrow> ('a, 'b) imap \<Rightarrow> bool"
+where
+    "DELETE_atSource_pre e I = (\<exists> (a,_) \<in> folderset I . a = e)"
 
 definition DELETE_downstream ::
-	"'a \<Rightarrow> 'a orset \<Rightarrow> ('a, 'b) imap \<Rightarrow> ('a, 'b) imap"
-	where
-	"DELETE_downstream e R I = (remove_downstream R (folderset I), (filesystem I)(e := None))"	
-	
-definition APPEND_atSource ::
-  "'a \<Rightarrow> 'b \<Rightarrow> ('a, 'b) imap \<Rightarrow> bool"
+    "'a \<Rightarrow> 'a orset \<Rightarrow> ('a, 'b) imap \<Rightarrow> ('a, 'b) imap"
 where
-  "APPEND_atSource f m I = (\<exists> (a,_) \<in> folderset I . a = f \<and> \<not> msgLookup f m I)"
+    "DELETE_downstream e R I = (remove_downstream R (folderset I), (filesystem I)(e := None))"
+
+
+definition APPEND_atSource ::
+    "'a \<Rightarrow> 'b \<Rightarrow> ('a, 'b) imap \<Rightarrow> bool"
+where
+    "APPEND_atSource f m I = (\<exists> (a,_) \<in> folderset I . a = f \<and> \<not> msgLookup f m I)"
 
 definition APPEND_downstream ::
-  "'a \<Rightarrow> 'b \<Rightarrow> ('a, 'b) imap \<Rightarrow> ('a, 'b) imap"
+    "'a \<Rightarrow> 'b \<Rightarrow> ('a, 'b) imap \<Rightarrow> ('a, 'b) imap"
 where
-  "APPEND_downstream f m I = 
-	(folderset I, 
-		(case (filesystem I)(f) of 
-			None \<Rightarrow> filesystem I | 
-			Some msgset \<Rightarrow> (filesystem I)(f := Some (msgset \<union> {m})))
-	)"
-	
-definition STORE_atSource ::
-  "'a \<Rightarrow> 'b \<Rightarrow> 'b \<Rightarrow> ('a, 'b) imap \<Rightarrow> bool"
-where
-  "STORE_atSource f msgold msgnew I = ((\<exists> (a,_) \<in> folderset I . a = f) \<and> msgLookup f msgold I \<and> \<not>(msgLookup f msgnew I))"
-	
-definition STORE_downstream ::
-  "'a \<Rightarrow> 'b \<Rightarrow> 'b \<Rightarrow> ('a, 'b) imap \<Rightarrow> ('a, 'b) imap"
-where
-  "STORE_downstream f msgold msgnew I = 
-	(folderset I, 
-		(case (filesystem I)(f) of 
-			None \<Rightarrow> filesystem I | 
-			Some msgset \<Rightarrow> (filesystem I)(f := Some (replaceMsg msgold msgnew msgset)))
-	)"
-	
-definition EXPUNGE_atSource ::
-  "'a \<Rightarrow> 'b \<Rightarrow> ('a, 'b) imap \<Rightarrow> bool"
-where
-  "EXPUNGE_atSource f m I = ((\<exists> (a,_) \<in> folderset I . a = f) \<and> msgLookup f m I)"
-  
-definition EXPUNGE_downstream ::
-  "'a \<Rightarrow> 'b \<Rightarrow> ('a, 'b) imap \<Rightarrow> ('a, 'b) imap"
-  where
-    "EXPUNGE_downstream f m I = 
-    (folderset I, 
-      (case (filesystem I)(f) of 
-        None \<Rightarrow> filesystem I | 
-        Some msgset \<Rightarrow> (filesystem I)(f := Some (msgset - {m}))))"
-	
--- "########## END OPERATIONS ##########"
+    "APPEND_downstream f m I =
+    (folderset I,
+    (case (filesystem I)(f) of
+        None \<Rightarrow> filesystem I |
+        Some msgset \<Rightarrow> (filesystem I)(f := Some (msgset \<union> {m}))
+    ))"
 
--- "####### BEGIN HELPING LEMMAS #######"
+
+definition STORE_atSource ::
+    "'a \<Rightarrow> 'b \<Rightarrow> 'b \<Rightarrow> ('a, 'b) imap \<Rightarrow> bool"
+where
+    "STORE_atSource f msgold msgnew I = ((\<exists> (a,_) \<in> folderset I . a = f) \<and> msgLookup f msgold I \<and> \<not>(msgLookup f msgnew I))"
+
+definition STORE_downstream ::
+    "'a \<Rightarrow> 'b \<Rightarrow> 'b \<Rightarrow> ('a, 'b) imap \<Rightarrow> ('a, 'b) imap"
+where
+    "STORE_downstream f msgold msgnew I =
+    (folderset I,
+    (case (filesystem I)(f) of
+        None \<Rightarrow> filesystem I |
+        Some msgset \<Rightarrow> (filesystem I)(f := Some (replaceMsg msgold msgnew msgset))
+    ))"
+
+
+definition EXPUNGE_atSource ::
+    "'a \<Rightarrow> 'b \<Rightarrow> ('a, 'b) imap \<Rightarrow> bool"
+where
+    "EXPUNGE_atSource f m I = ((\<exists> (a,_) \<in> folderset I . a = f) \<and> msgLookup f m I)"
+
+definition EXPUNGE_downstream ::
+    "'a \<Rightarrow> 'b \<Rightarrow> ('a, 'b) imap \<Rightarrow> ('a, 'b) imap"
+where
+    "EXPUNGE_downstream f m I =
+    (folderset I,
+    (case (filesystem I)(f) of
+        None \<Rightarrow> filesystem I |
+        Some msgset \<Rightarrow> (filesystem I)(f := Some (msgset - {m}))
+    ))"
+
+
+
+-- "########################"
+-- "### Auxiliary Lemmas ###"
+-- "########################"
+
 
 lemma append_not_none:
 fixes
-  I :: "('a, 'b) imap" and
-  f1 :: "'a" and
-  m1 :: "'b"
+    I :: "('a, 'b) imap" and
+    f1 :: "'a" and
+    m1 :: "'b"
 assumes
-	O1pre: " APPEND_atSource f1 m1 I" and
-	validS: "validState I"
+    O1pre: " APPEND_atSource f1 m1 I" and
+    validS: "validState I"
 shows "filesystem (APPEND_downstream f1 m1 I) f1 \<noteq> None"
 proof -
-	have "filesystem I f1 \<noteq> None" using O1pre validS unfolding validState_def APPEND_atSource_def by auto
-
-	thus ?thesis using validS O1pre unfolding APPEND_downstream_def validState_def APPEND_atSource_def by auto
+    have "filesystem I f1 \<noteq> None" using O1pre validS unfolding validState_def APPEND_atSource_def by auto
+    thus ?thesis using validS O1pre unfolding APPEND_downstream_def validState_def APPEND_atSource_def by auto
 qed
-  
+
+
 lemma append_folderset:
 fixes
-  I :: "('a, 'b) imap" and
-  f :: "'a" and
-  m :: "'b"
+    I :: "('a, 'b) imap" and
+    f :: "'a" and
+    m :: "'b"
 shows "folderset (APPEND_downstream f m I) = folderset I"
 proof -
-	show ?thesis unfolding APPEND_downstream_def by auto
+    show ?thesis unfolding APPEND_downstream_def by auto
 qed
-	
+
+
 lemma append_filesystem:
 fixes
-  I :: "('a, 'b) imap" and
-  f1 :: "'a" and
-  m1 :: "'b"
+    I :: "('a, 'b) imap" and
+    f1 :: "'a" and
+    m1 :: "'b"
 assumes
-	O1pre: " APPEND_atSource f1 m1 I" and
-	validS: "validState I"
+    O1pre: " APPEND_atSource f1 m1 I" and
+    validS: "validState I"
 shows "\<forall> f . f \<noteq> f1 \<longrightarrow> filesystem (APPEND_downstream f1 m1 I) f = filesystem I f"
 proof (simp add: APPEND_downstream_def option.case_eq_if)
 qed
 
+
 lemma store_folderset:
 fixes
-  I :: "('a, 'b) imap" and
-  f :: "'a"
+    I :: "('a, 'b) imap" and
+    f :: "'a"
 shows "folderset (STORE_downstream f msgold msgnew I) = folderset I"
 proof -
-	show ?thesis unfolding STORE_downstream_def by auto
+    show ?thesis unfolding STORE_downstream_def by auto
 qed
+
 
 lemma store_filesystem:
 fixes
-  I :: "('a, 'b) imap" and
-  f1 :: "'a"
+    I :: "('a, 'b) imap" and
+    f1 :: "'a"
 shows "\<forall> f. f \<noteq> f1 \<longrightarrow> filesystem (STORE_downstream f1 msgold msgnew I) f = filesystem I f"
 proof -
-	show ?thesis unfolding STORE_downstream_def by (simp add: option.case_eq_if)
+    show ?thesis unfolding STORE_downstream_def by (simp add: option.case_eq_if)
 qed
-  
+
+
 lemma store_not_none:
 fixes
-  I :: "('a, 'b) imap" and
-  f1 :: "'a" and
-  msgold :: "'b" and
-  msgnew :: "'b"
+    I :: "('a, 'b) imap" and
+    f1 :: "'a" and
+    msgold :: "'b" and
+    msgnew :: "'b"
 assumes
-  pre: "STORE_atSource f1 msgold msgnew I"
+    pre: "STORE_atSource f1 msgold msgnew I"
 shows "filesystem (STORE_downstream f1 msgold msgnew I) f1 \<noteq> None"
 proof -
-	show ?thesis using pre unfolding STORE_downstream_def STORE_atSource_def msgLookup_def
-	  by (metis fun_upd_same option.case_eq_if option.simps(3) snd_conv)
+    show ?thesis using pre unfolding STORE_downstream_def STORE_atSource_def msgLookup_def
+    by (metis fun_upd_same option.case_eq_if option.simps(3) snd_conv)
 qed
 
 
--- "######## END HELPING LEMMAS ########"
 
--- "###### BEGIN VALIDITY LEMMAS #######"
+-- "#########################################"
+-- "### Closure Proofs of IMAP Operations ###"
+-- "#########################################"
+
+
+lemma create_valid:
+fixes
+    I :: "('a, 'b) imap" and
+    e :: "'a" and
+    n :: nat
+assumes
+    validS: "validState I"
+shows "validState (CREATE_downstream e n I)"
+proof -
+    show ?thesis using validS unfolding CREATE_downstream_def add_def validState_def CREATE_atSource_def apply simp
+    by (simp add: split_def)
+qed
+
+
+lemma delete_valid:
+fixes
+    I :: "('a, 'b) imap" and
+    R :: "'a orset" and
+    e1 :: "'a"
+assumes
+    O1pre: "R = DELETE_atSource e1 I" and
+    validS: "validState I"
+shows "validState (DELETE_downstream e1 R I)"
+proof -
+    have A1: "\<forall> (a,b) \<in> folderset I. a \<noteq> e1 \<longrightarrow> (a,b) \<in> folderset (DELETE_downstream e1 R I)"
+    using O1pre unfolding DELETE_downstream_def remove_downstream_def DELETE_atSource_def remove_atSource_def by auto
+    have "\<forall> (a,_) \<in> folderset (DELETE_downstream e1 R I). a \<noteq> e1" using O1pre
+    unfolding DELETE_downstream_def remove_downstream_def DELETE_atSource_def remove_atSource_def by auto
+    hence "(\<forall> (a,_) \<in> folderset (DELETE_downstream e1 R I) . (filesystem (DELETE_downstream e1 R I)) a \<noteq> None)" using validS
+    unfolding validState_def  DELETE_downstream_def remove_downstream_def DELETE_atSource_def remove_atSource_def by fastforce
+    thus ?thesis using validS A1 unfolding validState_def DELETE_atSource_def DELETE_downstream_def remove_atSource_def
+    remove_downstream_def apply simp by blast
+qed
+
 
 lemma append_valid:
 fixes
-  I :: "('a, 'b) imap" and
-  f1 :: "'a" and
-  m1 :: "'b"
+    I :: "('a, 'b) imap" and
+    f1 :: "'a" and
+    m1 :: "'b"
 assumes
-	O1pre: " APPEND_atSource f1 m1 I" and
-	validS: "validState I"
+    O1pre: " APPEND_atSource f1 m1 I" and
+    validS: "validState I"
 shows "validState (APPEND_downstream f1 m1 I)"
 proof -
-	have "folderset (APPEND_downstream f1 m1 I) = folderset I" unfolding APPEND_downstream_def by auto
-	hence "(\<forall>f. filesystem (APPEND_downstream f1 m1 I) f \<noteq> None \<longrightarrow> (\<exists>(a,_)\<in>folderset (APPEND_downstream f1 m1 I). a = f))"
-		using O1pre by (metis (no_types, lifting) APPEND_atSource_def append_filesystem case_prod_beta' validS validState_def)
-	thus ?thesis using O1pre validS unfolding validState_def APPEND_downstream_def apply simp
-		by (smt case_prodE fun_upd_apply old.prod.case option.case_eq_if)
+    have "folderset (APPEND_downstream f1 m1 I) = folderset I" unfolding APPEND_downstream_def by auto
+    hence "(\<forall>f. filesystem (APPEND_downstream f1 m1 I) f \<noteq> None \<longrightarrow> (\<exists>(a,_)\<in>folderset (APPEND_downstream f1 m1 I). a = f))"
+    using O1pre by (metis (no_types, lifting) APPEND_atSource_def append_filesystem case_prod_beta' validS validState_def)
+    thus ?thesis using O1pre validS unfolding validState_def APPEND_downstream_def apply simp
+    by (smt case_prodE fun_upd_apply old.prod.case option.case_eq_if)
 qed
-	
-lemma delete_valid:
-fixes
-  I :: "('a, 'b) imap" and
-  R :: "'a orset" and
-  e1 :: "'a"
-assumes
-	O1pre: "R = DELETE_atSource e1 I" and
-	validS: "validState I"
-shows "validState (DELETE_downstream e1 R I)"
-proof -
-  have A1: "\<forall> (a,b) \<in> folderset I. a \<noteq> e1 \<longrightarrow> (a,b) \<in> folderset (DELETE_downstream e1 R I)"	
-  	using O1pre unfolding DELETE_downstream_def remove_downstream_def DELETE_atSource_def remove_atSource_def by auto
-  have "\<forall> (a,_) \<in> folderset (DELETE_downstream e1 R I). a \<noteq> e1" using O1pre 
-  	unfolding DELETE_downstream_def remove_downstream_def DELETE_atSource_def remove_atSource_def by auto
-  hence "(\<forall> (a,_) \<in> folderset (DELETE_downstream e1 R I) . (filesystem (DELETE_downstream e1 R I)) a \<noteq> None)" using validS
-  	unfolding validState_def  DELETE_downstream_def remove_downstream_def DELETE_atSource_def remove_atSource_def by fastforce
-	thus ?thesis using validS A1 unfolding validState_def DELETE_atSource_def DELETE_downstream_def remove_atSource_def 
-		remove_downstream_def apply simp by blast
-qed
-  
-lemma create_valid:
-fixes
-  I :: "('a, 'b) imap" and
-  e :: "'a" and
-  n :: nat
-assumes
-	validS: "validState I"
-shows "validState (CREATE_downstream e n I)"
-proof -
-  show ?thesis using validS unfolding CREATE_downstream_def add_def validState_def CREATE_atSource_def apply simp 
-    by (simp add: split_def)
-qed
-  
+
+
 lemma store_valid:
 fixes
-  I :: "('a, 'b) imap" and
-  f :: "'a" and
-  msgold :: "'b" and
-  msgnew :: "'b"
+    I :: "('a, 'b) imap" and
+    f :: "'a" and
+    msgold :: "'b" and
+    msgnew :: "'b"
 assumes
-  O1pre : "STORE_atSource f msgold msgnew I" and
-	validS: "validState I"
+    O1pre : "STORE_atSource f msgold msgnew I" and
+    validS: "validState I"
 shows "validState (STORE_downstream f msgold msgnew I)"
 proof -
-  show ?thesis using O1pre validS unfolding STORE_downstream_def STORE_atSource_def msgLookup_def replaceMsg_def
+    show ?thesis using O1pre validS unfolding STORE_downstream_def STORE_atSource_def msgLookup_def replaceMsg_def
     by (simp add: case_prod_beta' fun_upd_same option.case_eq_if validState_def)
 qed
-  
+
+
 lemma expunge_valid:
 fixes
-  I :: "('a, 'b) imap" and
-  f :: "'a" and
-  m :: "'b"
+    I :: "('a, 'b) imap" and
+    f :: "'a" and
+    m :: "'b"
 assumes
-  O1pre: "EXPUNGE_atSource f m I" and
-	validS: "validState I" 
+    O1pre: "EXPUNGE_atSource f m I" and
+    validS: "validState I"
 shows "validState (EXPUNGE_downstream f m I)"
 proof -
-  show ?thesis using O1pre validS unfolding EXPUNGE_atSource_def EXPUNGE_downstream_def msgLookup_def validState_def
+    show ?thesis using O1pre validS unfolding EXPUNGE_atSource_def EXPUNGE_downstream_def msgLookup_def validState_def
     by (simp add: case_prod_beta' option.case_eq_if)
 qed
 
--- "####### END VALIDITY LEMMAS ########"  
 
--- "####### BEGIN COMMUTATIVITY ########"
 
--- "done:"
--- "CREATE vs CREATE"
--- "DELETE vs DELETE"
--- "APPEND vs APPEND"
--- "STORE vs STORE"
--- "CREATE vs DELETE"
--- "CREATE vs APPEND"
--- "CREATE vs STORE"
--- "DELETE vs APPEND"
--- "DELETE vs STORE"
--- "APPEND vs STORE"
--- "EXPUNGE vs CREATE"
--- "EXPUNGE vs DELETE"
--- "EXPUNGE vs EXPUNGE"
--- "EXPUNGE vs APPEND"
--- "EXPUNGE vs STORE"
+-- "###############################################"
+-- "### Commutativity Proofs of IMAP Operations ###"
+-- "###############################################"
 
+-- "        CREATE DELETE APPEND STORE EXPUNGE"
+-- "                                          "
+-- " CREATE    1      2     3      4      5   "
+-- "                                          "
+-- " DELETE    2      6     7      8      9   "
+-- "                                          "
+-- " APPEND    3      7    10     11     12   "
+-- "                                          "
+-- "  STORE    4      8    11     13     14   "
+-- "                                          "
+-- "EXPUNGE    5      9    12     14     15   "
+
+
+
+-- "Case 1"
 lemma commCREATE:
 fixes
-  I :: "('a,'b) imap" and
-  e1 :: "'a" and
-  e2 :: "'a" and
-  n1 :: nat and
-  n2 :: nat
+    I :: "('a,'b) imap" and
+    e1 :: "'a" and
+    e2 :: "'a" and
+    n1 :: nat and
+    n2 :: nat
 assumes
-	n1neqn2: "n1 \<noteq> n2"
-shows 
-	"CREATE_downstream e1 n1 (CREATE_downstream e2 n2 I) = CREATE_downstream e2 n2 (CREATE_downstream e1 n1 I)"
+    n1neqn2: "n1 \<noteq> n2"
+shows "CREATE_downstream e1 n1 (CREATE_downstream e2 n2 I) = CREATE_downstream e2 n2 (CREATE_downstream e1 n1 I)"
 proof -
-	show ?thesis unfolding CREATE_downstream_def using commAdd n1neqn2 by fastforce
-qed
-	
-lemma commDELETE:
-fixes
-  I :: "('a, 'b) imap" and
-  R1 :: "'a orset" and
-  R2 :: "'a orset" and
-  e1 :: "'a" and
-  e2 :: "'a"
-assumes 
-  O1R1: " R1 = DELETE_atSource e1 I" and
-  O2R2: " R2 = DELETE_atSource e2 I"
-shows "DELETE_downstream e2 R2 (DELETE_downstream e1 R1 I) = DELETE_downstream e1 R1 (DELETE_downstream e2 R2 I)"
-proof -
-	show ?thesis using O1R1 O2R2 commRemove unfolding DELETE_downstream_def DELETE_atSource_def remove_atSource_def apply simp
-	proof -
-		assume a1: "R1 = {(a, b). (a, b) \<in> folderset I \<and> a = e1}"
-		assume a2: "R2 = {(a, b). (a, b) \<in> folderset I \<and> a = e2}"
-		have f3: "\<forall>P a Pa Pb aa. (P \<noteq> remove_atSource (a::'a) Pa \<or> Pb \<noteq> remove_atSource aa Pa) \<or> remove_downstream Pb (remove_downstream P Pa) = remove_downstream P (remove_downstream Pb Pa)"
-			by (meson commRemove)
-		have f4: "{(a, n). (a, n) \<in> folderset I \<and> a = e1} = remove_atSource e1 (folderset I)"
-			using a1 by (simp add: DELETE_atSource_def O1R1)
-		have "{(a, n). (a, n) \<in> folderset I \<and> a = e2} = remove_atSource e2 (folderset I)"
-			using a2 by (simp add: DELETE_atSource_def O2R2)
-		then show "remove_downstream {(a, n). (a, n) \<in> folderset I \<and> a = e2} (remove_downstream {(a, n). (a, n) \<in> folderset I \<and> a = e1} (folderset I)) = remove_downstream {(a, n). (a, n) \<in> folderset I \<and> a = e1} (remove_downstream {(a, n). (a, n) \<in> folderset I \<and> a = e2} (folderset I)) \<and> (filesystem I)(e1 := None, e2 := None) = (filesystem I) (e2 := None, e1 := None)"
-			using f4 f3 by auto
-	qed
-qed
-  
-lemma commAPPEND:
-fixes
-  I :: "('a, 'b) imap" and
-  f1 :: "'a" and
-  f2 :: "'a" and
-  m1 :: "'b" and
-  m2 :: "'b"
-assumes 
-  O1pre: " APPEND_atSource f1 m1 I" and
-  O2pre: " APPEND_atSource f2 m2 I" and
-	freshm: "m1 \<noteq> m2"
-shows "APPEND_downstream f1 m1 (APPEND_downstream f2 m2 I) = APPEND_downstream f2 m2 (APPEND_downstream f1 m1 I)"
-proof -
-	have A1: "folderset(APPEND_downstream f1 m1 (APPEND_downstream f2 m2 I)) = folderset(APPEND_downstream f2 m2 (APPEND_downstream f1 m1 I))"
-		by (simp add: APPEND_downstream_def)
-		
-	have "filesystem(APPEND_downstream f1 m1 (APPEND_downstream f2 m2 I)) = filesystem(APPEND_downstream f2 m2 (APPEND_downstream f1 m1 I))"
-		using O1pre O2pre freshm  unfolding APPEND_downstream_def APPEND_atSource_def msgLookup_def 
-		by (smt Un_insert_right fun_upd_twist fun_upd_upd insert_commute map_upd_Some_unfold option.case_eq_if option.collapse option.simps(3) snd_conv sup_bot.right_neutral)
-	thus ?thesis using A1	by (simp add: prod_eq_iff)
-qed
-  
-lemma commSTORE:
-fixes
-  I :: "('a, 'b) imap" and
-  f1 :: "'a" and
-  f2 :: "'a" and
-  mo1 :: "'b" and
-  mo2 :: "'b" and
-  mn1 :: "'b" and
-  mn2 :: "'b"
-assumes 
-  O1pre: " STORE_atSource f1 mo1 mn1 I" and
-  O2pre: " STORE_atSource f2 mo2 mn2 I" 
-shows "STORE_downstream f1 mo1 mn1 (STORE_downstream f2 mo2 mn2 I) = STORE_downstream f2 mo2 mn2 (STORE_downstream f1 mo1 mn1 I)"
-proof -
-  have A1: "folderset (STORE_downstream f1 mo1 mn1 (STORE_downstream f2 mo2 mn2 I)) = folderset(STORE_downstream f2 mo2 mn2 (STORE_downstream f1 mo1 mn1 I))"
-    by (simp add: store_folderset)
-  
-  have  A5: "\<forall> f . f1 \<noteq> f2 \<longrightarrow> filesystem (STORE_downstream f1 mo1 mn1 (STORE_downstream f2 mo2 mn2 I)) f = filesystem(STORE_downstream f2 mo2 mn2 (STORE_downstream f1 mo1 mn1 I)) f"
-    by (smt STORE_downstream_def fun_upd_twist option.case_eq_if snd_conv store_filesystem)
-    
-  have  "f1 = f2 \<longrightarrow> filesystem (STORE_downstream f1 mo1 mn1 (STORE_downstream f2 mo2 mn2 I)) f1 = filesystem(STORE_downstream f2 mo2 mn2 (STORE_downstream f1 mo1 mn1 I)) f1"
-  proof auto
-    assume Ass: "f1 = f2"
-    hence  "filesystem (STORE_downstream f1 mo1 mn1 (STORE_downstream f2 mo2 mn2 I)) f1 \<noteq> None"
-      by (smt O2pre STORE_downstream_def fun_upd_eqD fun_upd_triv option.case_eq_if option.simps(3) snd_conv store_not_none)
-  
-    hence "\<exists> y . filesystem (STORE_downstream f1 mo1 mn1 (STORE_downstream f2 mo2 mn2 I)) f1 = Some y"
-      by simp
-    
-    then obtain y where Ass4: "filesystem (STORE_downstream f1 mo1 mn1 (STORE_downstream f2 mo2 mn2 I)) f1 = Some y" by blast
-    
-    have "\<exists> S . filesystem (I) f1 = Some S" by (metis O2pre STORE_atSource_def \<open>f1 = f2\<close> case_optionE msgLookup_def)
-    then obtain S where Ass2: "(filesystem I) f1 = Some S" by blast
-        
-    have "\<exists> x . filesystem (STORE_downstream f2 mo2 mn2 I) f1 = Some x" using Ass by (metis O2pre option.collapse store_not_none) 
-    then obtain x where Ass3: "filesystem (STORE_downstream f2 mo2 mn2 I) f1 = Some x" by blast
-        
-    have "x = (S - {mo2}) \<union> {mn2}" using Ass Ass2 Ass3 unfolding STORE_downstream_def replaceMsg_def  by simp    
-        
-    hence Ass6: "y = (S - {mo1,mo2}) \<union> {mn1,mn2}" using Ass Ass2 Ass3 Ass4 O1pre O2pre unfolding STORE_downstream_def replaceMsg_def STORE_atSource_def
-      by auto
-        
-    have "\<exists> w . filesystem (STORE_downstream f1 mo1 mn1 I) f1 = Some w" using Ass by (metis O1pre option.collapse store_not_none)
-    then obtain w where Ass8: "filesystem (STORE_downstream f1 mo1 mn1 I) f1 = Some w" by blast
-        
-    hence Ass9: "w = (S - {mo1}) \<union> {mn1}" using Ass Ass2 unfolding STORE_downstream_def replaceMsg_def by simp
-        
-    have "filesystem(STORE_downstream f2 mo2 mn2 (STORE_downstream f1 mo1 mn1 I)) f1 \<noteq> None" using O1pre 
-        unfolding STORE_downstream_def using Ass Ass2 by auto
-      
-    hence "\<exists> z . filesystem(STORE_downstream f2 mo2 mn2 (STORE_downstream f1 mo1 mn1 I)) f1 = Some z"
-      by simp
-      
-    then obtain z where Ass7: "filesystem(STORE_downstream f2 mo2 mn2 (STORE_downstream f1 mo1 mn1 I)) f1 = Some z" by blast
-        
-    hence "z = (S - {mo1,mo2}) \<union> {mn1,mn2}" using Ass Ass2 Ass9 Ass8 O1pre O2pre unfolding STORE_downstream_def replaceMsg_def STORE_atSource_def by auto
-    
-    thus "filesystem (STORE_downstream f2 mo1 mn1 (STORE_downstream f2 mo2 mn2 I)) f2 =
-    filesystem (STORE_downstream f2 mo2 mn2 (STORE_downstream f2 mo1 mn1 I)) f2" using Ass7 Ass4 Ass6 Ass by auto
-  qed
-  thus ?thesis using A1 A5
-    by (smt O1pre O2pre STORE_downstream_def fun_upd_same fun_upd_twist fun_upd_upd option.case_eq_if prod_eqI snd_conv store_not_none)
-qed
-  
-lemma commEXPUNGE:
-fixes
-  I :: "('a, 'b) imap" and
-  f1 :: "'a" and
-  f2 :: "'a" and
-  m1 :: "'b" and
-  m2 :: "'b" 
-assumes 
-  O1pre: " EXPUNGE_atSource f1 m1 I" and
-  O2pre: " EXPUNGE_atSource f2 m2 I" 
-shows "EXPUNGE_downstream f1 m1 (EXPUNGE_downstream f2 m2 I) = EXPUNGE_downstream f2 m2 (EXPUNGE_downstream f1 m1 I)"
-proof -
-  have A1: "folderset (EXPUNGE_downstream f1 m1 (EXPUNGE_downstream f2 m2 I)) = folderset (EXPUNGE_downstream f2 m2 (EXPUNGE_downstream f1 m1 I))"
-    unfolding EXPUNGE_downstream_def EXPUNGE_atSource_def by simp
-  have "filesystem (EXPUNGE_downstream f1 m1 (EXPUNGE_downstream f2 m2 I)) = filesystem (EXPUNGE_downstream f2 m2 (EXPUNGE_downstream f1 m1 I))"
-    using O1pre O2pre unfolding EXPUNGE_downstream_def EXPUNGE_atSource_def msgLookup_def
-    by (smt Diff_insert fun_upd_twist fun_upd_upd insert_commute map_upd_Some_unfold option.case_eq_if option.collapse option.simps(3) snd_conv)
-  thus ?thesis using A1 by (simp add: prod_eqI)
+    show ?thesis unfolding CREATE_downstream_def using commAdd n1neqn2 by fastforce
 qed
 
-lemma commCREATE_STORE:
-fixes
-  I :: "('a, 'b) imap" and
-  f1 :: "'a" and
-  f2 :: "'a" and
-  mo :: "'b" and
-  mn :: "'b" and
-  n :: nat
-assumes 
-  O1pre: " STORE_atSource f1 mo mn I" and
-  O2pre: " CREATE_atSource f2 I"
-shows "STORE_downstream f1 mo mn (CREATE_downstream f2 n I) = CREATE_downstream f2 n (STORE_downstream f1 mo mn I)"
-proof - 
-  have A1: "folderset (STORE_downstream f1 mo mn (CREATE_downstream f2 n I)) = folderset (CREATE_downstream f2 n (STORE_downstream f1 mo mn I))"
-    by (simp add: CREATE_downstream_def store_folderset)
-  have "filesystem (STORE_downstream f1 mo mn (CREATE_downstream f2 n I)) = filesystem (CREATE_downstream f2 n (STORE_downstream f1 mo mn I))"
-    using O1pre O2pre unfolding STORE_downstream_def CREATE_downstream_def CREATE_atSource_def STORE_atSource_def
-    by (smt case_prodE fun_upd_other fun_upd_twist option.case_eq_if snd_conv)
-  thus ?thesis using A1 by (simp add: prod.expand)
-qed
-  
-lemma commDELETE_STORE:
-fixes
-  I :: "('a, 'b) imap" and
-  f1 :: "'a" and
-  f2 :: "'a" and
-  mo :: "'b" and
-  mn :: "'b" and
-  R :: "'a orset"
-assumes 
-  O1pre: " STORE_atSource f1 mo mn I" and
-  O2pre: " R = DELETE_atSource f2 I"
-shows "STORE_downstream f1 mo mn (DELETE_downstream f2 R I) = DELETE_downstream f2 R (STORE_downstream f1 mo mn I)"
-proof - 
-  have A1: "folderset (STORE_downstream f1 mo mn (DELETE_downstream f2 R I)) = folderset(DELETE_downstream f2 R (STORE_downstream f1 mo mn I))"
-    by (simp add: DELETE_downstream_def store_folderset)
-  have "filesystem (STORE_downstream f1 mo mn (DELETE_downstream f2 R I)) = filesystem(DELETE_downstream f2 R (STORE_downstream f1 mo mn I))"
-    using O1pre O2pre unfolding STORE_downstream_def DELETE_downstream_def DELETE_atSource_def STORE_atSource_def
-    by (simp add: fun_upd_twist option.case_eq_if)
-  thus ?thesis using A1 by (simp add: prod.expand)
-qed
-  
-lemma commAPPEND_STORE:
-fixes
-  I :: "('a, 'b) imap" and
-  f1 :: "'a" and
-  f2 :: "'a" and
-  mo :: "'b" and
-  mn :: "'b" and
-  m :: "'b"
-assumes 
-  O1pre: " STORE_atSource f1 mo mn I" and
-  O2pre: " APPEND_atSource f2 m I" and
-  freshmn: "m \<noteq> mn" and
-  freshmo: "m \<noteq> mo"
-shows "STORE_downstream f1 mo mn (APPEND_downstream f2 m I) = APPEND_downstream f2 m (STORE_downstream f1 mo mn I)"
-proof - 
-  have A1: "folderset (STORE_downstream f1 mo mn (APPEND_downstream f2 m I)) = folderset (APPEND_downstream f2 m (STORE_downstream f1 mo mn I))"
-    by (simp add: APPEND_downstream_def store_folderset)
-      
-  have "filesystem (STORE_downstream f1 mo mn (APPEND_downstream f2 m I)) = filesystem(APPEND_downstream f2 m (STORE_downstream f1 mo mn I))"
-    using O1pre O2pre freshmn freshmo unfolding STORE_downstream_def APPEND_downstream_def APPEND_atSource_def STORE_atSource_def replaceMsg_def
-      by (smt Diff_insert0 Un_Diff Un_Diff_cancel2 Un_insert_right empty_iff fun_upd_twist fun_upd_upd insert_iff insert_is_Un map_upd_Some_unfold option.case_eq_if option.collapse option.simps(5) snd_conv sup_bot.right_neutral)      
-  thus ?thesis using A1 by (simp add: prod.expand)
-qed
-      
+
+-- "Case 2"
 lemma commCREATE_DELETE:
 fixes
-  I :: "('a, 'b) imap" and
-  R1 :: "'a orset" and
-  e1 :: "'a" and
-  e2 :: "'a" and
-  n :: nat
-assumes 
-  O1R1: " R1 = DELETE_atSource e1 I" and
-	freshn: "fresh n (folderset I)" and
-	O2pre: "CREATE_atSource e2 I" and
-	lookupe1: "lookup e1 (folderset I)"
+    I :: "('a, 'b) imap" and
+    R1 :: "'a orset" and
+    e1 :: "'a" and
+    e2 :: "'a" and
+    n :: nat
+assumes
+    O1R1: " R1 = DELETE_atSource e1 I" and
+    freshn: "fresh n (folderset I)" and
+    O2pre: "CREATE_atSource e2 I" and
+    lookupe1: "lookup e1 (folderset I)"
 shows "DELETE_downstream e1 R1 (CREATE_downstream e2 n I) = CREATE_downstream e2 n (DELETE_downstream e1 R1 I)"
 proof -
-	have fset: "folderset (DELETE_downstream e1 R1 (CREATE_downstream e2 n I)) = folderset (CREATE_downstream e2 n (DELETE_downstream e1 R1 I))"
-		using O1R1 freshn unfolding DELETE_downstream_def CREATE_downstream_def fresh_def commAddRemove 
-		  DELETE_atSource_def remove_atSource_def remove_downstream_def add_def by auto		  
-	have "filesystem (DELETE_downstream e1 R1 (CREATE_downstream e2 n I)) = filesystem (CREATE_downstream e2 n (DELETE_downstream e1 R1 I))" 
-	  using O1R1 O2pre lookupe1 unfolding DELETE_downstream_def CREATE_downstream_def DELETE_atSource_def remove_atSource_def CREATE_atSource_def validState_def
-		lookup_def by fastforce
-	thus ?thesis using fset unfolding DELETE_downstream_def by auto
+    have fset: "folderset (DELETE_downstream e1 R1 (CREATE_downstream e2 n I)) = folderset (CREATE_downstream e2 n (DELETE_downstream e1 R1 I))" using O1R1 freshn unfolding DELETE_downstream_def CREATE_downstream_def fresh_def commAddRemove DELETE_atSource_def remove_atSource_def remove_downstream_def add_def by auto
+
+    have "filesystem (DELETE_downstream e1 R1 (CREATE_downstream e2 n I)) = filesystem (CREATE_downstream e2 n (DELETE_downstream e1 R1 I))" using O1R1 O2pre lookupe1 unfolding DELETE_downstream_def CREATE_downstream_def DELETE_atSource_def remove_atSource_def CREATE_atSource_def validState_def lookup_def by fastforce
+
+    thus ?thesis using fset unfolding DELETE_downstream_def by auto
 qed
-  
+
+
+-- "Case 3"
 lemma commCREATE_APPEND:
 fixes
-  I :: "('a, 'b) imap" and
-  e :: "'a" and
-  n :: nat and
-  f :: "'a" and
-  m :: "'b"
-assumes 
-  O1pre: " APPEND_atSource f m I" and
-  O2pre: " CREATE_atSource e I"
+    I :: "('a, 'b) imap" and
+    e :: "'a" and
+    n :: nat and
+    f :: "'a" and
+    m :: "'b"
+assumes
+    O1pre: " APPEND_atSource f m I" and
+    O2pre: " CREATE_atSource e I"
 shows "APPEND_downstream f m (CREATE_downstream e n I) = CREATE_downstream e n (APPEND_downstream f m I)"
 proof -
-  have "filesystem(APPEND_downstream f m (CREATE_downstream e n I)) = filesystem(CREATE_downstream e n (APPEND_downstream f m I))"
-    using O1pre O2pre
-    unfolding APPEND_atSource_def APPEND_downstream_def CREATE_atSource_def CREATE_downstream_def
-    by (smt case_prodE fun_upd_apply fun_upd_twist option.case_eq_if prod.sel(2))
-	thus ?thesis using append_folderset[of f m I] unfolding APPEND_downstream_def CREATE_downstream_def by auto
+    have "filesystem(APPEND_downstream f m (CREATE_downstream e n I)) = filesystem(CREATE_downstream e n (APPEND_downstream f m I))" using O1pre O2pre unfolding APPEND_atSource_def APPEND_downstream_def CREATE_atSource_def CREATE_downstream_def by (smt case_prodE fun_upd_apply fun_upd_twist option.case_eq_if prod.sel(2))
+
+    thus ?thesis using append_folderset[of f m I] unfolding APPEND_downstream_def CREATE_downstream_def by auto
 qed
-  
-lemma commDELETE_APPEND:
+
+
+-- "Case 4"
+lemma commCREATE_STORE:
 fixes
-  I :: "('a, 'b) imap" and
-  f :: "'a" and
-  e :: "'a" and
-  m :: "'b" and
-  R :: "'a orset"
-assumes 
-  O1pre: " APPEND_atSource f m I" and
-  O2pre: " R = DELETE_atSource e I"
-shows "APPEND_downstream f m (DELETE_downstream e R I) = DELETE_downstream e R (APPEND_downstream f m I)"
+    I :: "('a, 'b) imap" and
+    f1 :: "'a" and
+    f2 :: "'a" and
+    mo :: "'b" and
+    mn :: "'b" and
+    n :: nat
+assumes
+    O1pre: " STORE_atSource f1 mo mn I" and
+    O2pre: " CREATE_atSource f2 I"
+shows "STORE_downstream f1 mo mn (CREATE_downstream f2 n I) = CREATE_downstream f2 n (STORE_downstream f1 mo mn I)"
 proof -
-  have A1: "folderset(APPEND_downstream f m (DELETE_downstream e R I)) = folderset(DELETE_downstream e R (APPEND_downstream f m I))"
-    unfolding DELETE_downstream_def by (simp add: append_folderset)
-  have "filesystem(APPEND_downstream f m (DELETE_downstream e R I)) = filesystem(DELETE_downstream e R (APPEND_downstream f m I))"
-    using O1pre O2pre unfolding APPEND_atSource_def APPEND_downstream_def DELETE_atSource_def DELETE_downstream_def 
-    by (simp add: fun_upd_twist option.case_eq_if)
-	thus ?thesis using A1 prod_eqI by blast
+    have A1: "folderset (STORE_downstream f1 mo mn (CREATE_downstream f2 n I)) = folderset (CREATE_downstream f2 n (STORE_downstream f1 mo mn I))" by (simp add: CREATE_downstream_def store_folderset)
+
+    have "filesystem (STORE_downstream f1 mo mn (CREATE_downstream f2 n I)) = filesystem (CREATE_downstream f2 n (STORE_downstream f1 mo mn I))" using O1pre O2pre unfolding STORE_downstream_def CREATE_downstream_def CREATE_atSource_def STORE_atSource_def by (smt case_prodE fun_upd_other fun_upd_twist option.case_eq_if snd_conv)
+
+    thus ?thesis using A1 by (simp add: prod.expand)
 qed
-  
-lemma commDELETE_EXPUNGE:
-fixes
-  I :: "('a, 'b) imap" and
-  f1 :: "'a" and
-  f2 :: "'a" and
-  m :: "'b" and
-  R :: "'a orset"
-assumes 
-  O1pre: " EXPUNGE_atSource f1 m I" and
-  O2pre: " R = DELETE_atSource f2 I"
-shows "EXPUNGE_downstream f1 m (DELETE_downstream f2 R I) = DELETE_downstream f2 R (EXPUNGE_downstream f1 m I)"
-proof -
-  have A1: "folderset(EXPUNGE_downstream f1 m (DELETE_downstream f2 R I)) = folderset (DELETE_downstream f2 R (EXPUNGE_downstream f1 m I))"
-    unfolding DELETE_downstream_def EXPUNGE_downstream_def by simp
-  have "filesystem(EXPUNGE_downstream f1 m (DELETE_downstream f2 R I)) = filesystem (DELETE_downstream f2 R (EXPUNGE_downstream f1 m I))"
-    using O1pre O2pre unfolding EXPUNGE_atSource_def EXPUNGE_downstream_def DELETE_atSource_def DELETE_downstream_def msgLookup_def      
-    by (simp add: fun_upd_twist option.case_eq_if)
-	thus ?thesis using A1 prod_eqI by blast
-qed
-  
+
+
+-- "Case 5"
 lemma commCREATE_EXPUNGE:
 fixes
-  I :: "('a, 'b) imap" and
-  f1 :: "'a" and
-  f2 :: "'a" and
-  m :: "'b" and
-  n :: nat
-assumes 
-  O1pre: " EXPUNGE_atSource f1 m I" and
-  O2pre: " CREATE_atSource f2 I"
+    I :: "('a, 'b) imap" and
+    f1 :: "'a" and
+    f2 :: "'a" and
+    m :: "'b" and
+    n :: nat
+assumes
+    O1pre: " EXPUNGE_atSource f1 m I" and
+    O2pre: " CREATE_atSource f2 I"
 shows "EXPUNGE_downstream f1 m (CREATE_downstream f2 n I) = CREATE_downstream f2 n (EXPUNGE_downstream f1 m I)"
 proof -
-  have A1: "folderset (EXPUNGE_downstream f1 m (CREATE_downstream f2 n I)) = folderset (CREATE_downstream f2 n (EXPUNGE_downstream f1 m I))"
-    unfolding CREATE_downstream_def EXPUNGE_downstream_def by simp
-  have "filesystem (EXPUNGE_downstream f1 m (CREATE_downstream f2 n I)) = filesystem (CREATE_downstream f2 n (EXPUNGE_downstream f1 m I))"
-    using O1pre O2pre unfolding EXPUNGE_atSource_def EXPUNGE_downstream_def CREATE_atSource_def CREATE_downstream_def      
-    by (simp add: fun_upd_twist option.case_eq_if)
-	thus ?thesis using A1 prod_eqI by blast
+    have A1: "folderset (EXPUNGE_downstream f1 m (CREATE_downstream f2 n I)) = folderset (CREATE_downstream f2 n (EXPUNGE_downstream f1 m I))" unfolding CREATE_downstream_def EXPUNGE_downstream_def by simp
+
+    have "filesystem (EXPUNGE_downstream f1 m (CREATE_downstream f2 n I)) = filesystem (CREATE_downstream f2 n (EXPUNGE_downstream f1 m I))" using O1pre O2pre unfolding EXPUNGE_atSource_def EXPUNGE_downstream_def CREATE_atSource_def CREATE_downstream_def by (simp add: fun_upd_twist option.case_eq_if)
+
+    thus ?thesis using A1 prod_eqI by blast
 qed
-  
+
+
+-- "Case 6"
+lemma commDELETE:
+fixes
+    I :: "('a, 'b) imap" and
+    R1 :: "'a orset" and
+    R2 :: "'a orset" and
+    e1 :: "'a" and
+    e2 :: "'a"
+assumes
+    O1R1: " R1 = DELETE_atSource e1 I" and
+    O2R2: " R2 = DELETE_atSource e2 I"
+shows "DELETE_downstream e2 R2 (DELETE_downstream e1 R1 I) = DELETE_downstream e1 R1 (DELETE_downstream e2 R2 I)"
+proof -
+    show ?thesis using O1R1 O2R2 commRemove unfolding DELETE_downstream_def DELETE_atSource_def remove_atSource_def apply simp
+    proof -
+        assume a1: "R1 = {(a, b). (a, b) \<in> folderset I \<and> a = e1}"
+        assume a2: "R2 = {(a, b). (a, b) \<in> folderset I \<and> a = e2}"
+
+        have f3: "\<forall>P a Pa Pb aa. (P \<noteq> remove_atSource (a::'a) Pa \<or> Pb \<noteq> remove_atSource aa Pa) \<or> remove_downstream Pb (remove_downstream P Pa) = remove_downstream P (remove_downstream Pb Pa)" by (meson commRemove)
+
+        have f4: "{(a, n). (a, n) \<in> folderset I \<and> a = e1} = remove_atSource e1 (folderset I)" using a1 by (simp add: DELETE_atSource_def O1R1)
+
+        have "{(a, n). (a, n) \<in> folderset I \<and> a = e2} = remove_atSource e2 (folderset I)" using a2 by (simp add: DELETE_atSource_def O2R2)
+
+        then show "remove_downstream {(a, n). (a, n) \<in> folderset I \<and> a = e2} (remove_downstream {(a, n). (a, n) \<in> folderset I \<and> a = e1} (folderset I)) = remove_downstream {(a, n). (a, n) \<in> folderset I \<and> a = e1} (remove_downstream {(a, n). (a, n) \<in> folderset I \<and> a = e2} (folderset I)) \<and> (filesystem I)(e1 := None, e2 := None) = (filesystem I) (e2 := None, e1 := None)" using f4 f3 by auto
+    qed
+qed
+
+
+-- "Case 7"
+lemma commDELETE_APPEND:
+fixes
+    I :: "('a, 'b) imap" and
+    f :: "'a" and
+    e :: "'a" and
+    m :: "'b" and
+    R :: "'a orset"
+assumes
+    O1pre: " APPEND_atSource f m I" and
+    O2pre: " R = DELETE_atSource e I"
+shows "APPEND_downstream f m (DELETE_downstream e R I) = DELETE_downstream e R (APPEND_downstream f m I)"
+proof -
+    have A1: "folderset(APPEND_downstream f m (DELETE_downstream e R I)) = folderset(DELETE_downstream e R (APPEND_downstream f m I))" unfolding DELETE_downstream_def by (simp add: append_folderset)
+
+    have "filesystem(APPEND_downstream f m (DELETE_downstream e R I)) = filesystem(DELETE_downstream e R (APPEND_downstream f m I))" using O1pre O2pre unfolding APPEND_atSource_def APPEND_downstream_def DELETE_atSource_def DELETE_downstream_def by (simp add: fun_upd_twist option.case_eq_if)
+
+    thus ?thesis using A1 prod_eqI by blast
+qed
+
+
+-- "Case 8"
+lemma commDELETE_STORE:
+fixes
+    I :: "('a, 'b) imap" and
+    f1 :: "'a" and
+    f2 :: "'a" and
+    mo :: "'b" and
+    mn :: "'b" and
+    R :: "'a orset"
+assumes
+    O1pre: " STORE_atSource f1 mo mn I" and
+    O2pre: " R = DELETE_atSource f2 I"
+shows "STORE_downstream f1 mo mn (DELETE_downstream f2 R I) = DELETE_downstream f2 R (STORE_downstream f1 mo mn I)"
+proof -
+    have A1: "folderset (STORE_downstream f1 mo mn (DELETE_downstream f2 R I)) = folderset(DELETE_downstream f2 R (STORE_downstream f1 mo mn I))" by (simp add: DELETE_downstream_def store_folderset)
+
+    have "filesystem (STORE_downstream f1 mo mn (DELETE_downstream f2 R I)) = filesystem(DELETE_downstream f2 R (STORE_downstream f1 mo mn I))" using O1pre O2pre unfolding STORE_downstream_def DELETE_downstream_def DELETE_atSource_def STORE_atSource_def by (simp add: fun_upd_twist option.case_eq_if)
+
+    thus ?thesis using A1 by (simp add: prod.expand)
+qed
+
+
+-- "Case 9"
+lemma commDELETE_EXPUNGE:
+fixes
+    I :: "('a, 'b) imap" and
+    f1 :: "'a" and
+    f2 :: "'a" and
+    m :: "'b" and
+    R :: "'a orset"
+assumes
+    O1pre: " EXPUNGE_atSource f1 m I" and
+    O2pre: " R = DELETE_atSource f2 I"
+shows "EXPUNGE_downstream f1 m (DELETE_downstream f2 R I) = DELETE_downstream f2 R (EXPUNGE_downstream f1 m I)"
+proof -
+    have A1: "folderset(EXPUNGE_downstream f1 m (DELETE_downstream f2 R I)) = folderset (DELETE_downstream f2 R (EXPUNGE_downstream f1 m I))" unfolding DELETE_downstream_def EXPUNGE_downstream_def by simp
+
+    have "filesystem(EXPUNGE_downstream f1 m (DELETE_downstream f2 R I)) = filesystem (DELETE_downstream f2 R (EXPUNGE_downstream f1 m I))" using O1pre O2pre unfolding EXPUNGE_atSource_def EXPUNGE_downstream_def DELETE_atSource_def DELETE_downstream_def msgLookup_def by (simp add: fun_upd_twist option.case_eq_if)
+
+    thus ?thesis using A1 prod_eqI by blast
+qed
+
+
+-- "Case 10"
+lemma commAPPEND:
+fixes
+    I :: "('a, 'b) imap" and
+    f1 :: "'a" and
+    f2 :: "'a" and
+    m1 :: "'b" and
+    m2 :: "'b"
+assumes
+    O1pre: " APPEND_atSource f1 m1 I" and
+    O2pre: " APPEND_atSource f2 m2 I" and
+    freshm: "m1 \<noteq> m2"
+shows "APPEND_downstream f1 m1 (APPEND_downstream f2 m2 I) = APPEND_downstream f2 m2 (APPEND_downstream f1 m1 I)"
+proof -
+    have A1: "folderset(APPEND_downstream f1 m1 (APPEND_downstream f2 m2 I)) = folderset(APPEND_downstream f2 m2 (APPEND_downstream f1 m1 I))" by (simp add: APPEND_downstream_def)
+
+    have "filesystem(APPEND_downstream f1 m1 (APPEND_downstream f2 m2 I)) = filesystem(APPEND_downstream f2 m2 (APPEND_downstream f1 m1 I))" using O1pre O2pre freshm  unfolding APPEND_downstream_def APPEND_atSource_def msgLookup_def by (smt Un_insert_right fun_upd_twist fun_upd_upd insert_commute map_upd_Some_unfold option.case_eq_if option.collapse option.simps(3) snd_conv sup_bot.right_neutral)
+
+    thus ?thesis using A1 by (simp add: prod_eq_iff)
+qed
+
+
+-- "Case 11"
+lemma commAPPEND_STORE:
+fixes
+    I :: "('a, 'b) imap" and
+    f1 :: "'a" and
+    f2 :: "'a" and
+    mo :: "'b" and
+    mn :: "'b" and
+    m :: "'b"
+assumes
+    O1pre: " STORE_atSource f1 mo mn I" and
+    O2pre: " APPEND_atSource f2 m I" and
+    freshmn: "m \<noteq> mn" and
+    freshmo: "m \<noteq> mo"
+shows "STORE_downstream f1 mo mn (APPEND_downstream f2 m I) = APPEND_downstream f2 m (STORE_downstream f1 mo mn I)"
+proof -
+    have A1: "folderset (STORE_downstream f1 mo mn (APPEND_downstream f2 m I)) = folderset (APPEND_downstream f2 m (STORE_downstream f1 mo mn I))" by (simp add: APPEND_downstream_def store_folderset)
+
+    have "filesystem (STORE_downstream f1 mo mn (APPEND_downstream f2 m I)) = filesystem(APPEND_downstream f2 m (STORE_downstream f1 mo mn I))" using O1pre O2pre freshmn freshmo unfolding STORE_downstream_def APPEND_downstream_def APPEND_atSource_def STORE_atSource_def replaceMsg_def by (smt Diff_insert0 Un_Diff Un_Diff_cancel2 Un_insert_right empty_iff fun_upd_twist fun_upd_upd insert_iff insert_is_Un map_upd_Some_unfold option.case_eq_if option.collapse option.simps(5) snd_conv sup_bot.right_neutral)
+
+    thus ?thesis using A1 by (simp add: prod.expand)
+qed
+
+
+-- "Case 12"
 lemma commAPPEND_EXPUNGE:
 fixes
-  I :: "('a, 'b) imap" and
-  f1 :: "'a" and
-  f2 :: "'a" and
-  m1 :: "'b" and
-  m2 :: "'b"
-assumes 
-  O1pre: "EXPUNGE_atSource f1 m1 I" and
-  O2pre: "APPEND_atSource f2 m2 I"
+    I :: "('a, 'b) imap" and
+    f1 :: "'a" and
+    f2 :: "'a" and
+    m1 :: "'b" and
+    m2 :: "'b"
+assumes
+    O1pre: "EXPUNGE_atSource f1 m1 I" and
+    O2pre: "APPEND_atSource f2 m2 I"
 shows "EXPUNGE_downstream f1 m1 (APPEND_downstream f2 m2 I) = APPEND_downstream f2 m2 (EXPUNGE_downstream f1 m1 I)"
 proof -
-  have A1: "folderset (EXPUNGE_downstream f1 m1 (APPEND_downstream f2 m2 I)) = folderset (APPEND_downstream f2 m2 (EXPUNGE_downstream f1 m1 I))"
-    unfolding EXPUNGE_downstream_def APPEND_downstream_def by simp
-  have "filesystem (EXPUNGE_downstream f1 m1 (APPEND_downstream f2 m2 I)) = filesystem (APPEND_downstream f2 m2 (EXPUNGE_downstream f1 m1 I))"
-    using O1pre O2pre unfolding EXPUNGE_downstream_def EXPUNGE_atSource_def APPEND_downstream_def APPEND_atSource_def
-    by (smt Diff_empty Diff_insert0 Un_Diff case_prod_beta' fun_upd_apply fun_upd_twist fun_upd_upd insert_Diff insert_Diff1 map_upd_eqD1 mk_disjoint_insert msgLookup_def option.case_eq_if option.collapse option.simps(3) singletonI snd_conv)
-	thus ?thesis using A1 prod_eqI by blast
+    have A1: "folderset (EXPUNGE_downstream f1 m1 (APPEND_downstream f2 m2 I)) = folderset (APPEND_downstream f2 m2 (EXPUNGE_downstream f1 m1 I))" unfolding EXPUNGE_downstream_def APPEND_downstream_def by simp
+
+    have "filesystem (EXPUNGE_downstream f1 m1 (APPEND_downstream f2 m2 I)) = filesystem (APPEND_downstream f2 m2 (EXPUNGE_downstream f1 m1 I))" using O1pre O2pre unfolding EXPUNGE_downstream_def EXPUNGE_atSource_def APPEND_downstream_def APPEND_atSource_def by (smt Diff_empty Diff_insert0 Un_Diff case_prod_beta' fun_upd_apply fun_upd_twist fun_upd_upd insert_Diff insert_Diff1 map_upd_eqD1 mk_disjoint_insert msgLookup_def option.case_eq_if option.collapse option.simps(3) singletonI snd_conv)
+
+    thus ?thesis using A1 prod_eqI by blast
 qed
-  
+
+
+-- "Case 13"
+lemma commSTORE:
+fixes
+    I :: "('a, 'b) imap" and
+    f1 :: "'a" and
+    f2 :: "'a" and
+    mo1 :: "'b" and
+    mo2 :: "'b" and
+    mn1 :: "'b" and
+    mn2 :: "'b"
+assumes
+    O1pre: " STORE_atSource f1 mo1 mn1 I" and
+    O2pre: " STORE_atSource f2 mo2 mn2 I"
+shows "STORE_downstream f1 mo1 mn1 (STORE_downstream f2 mo2 mn2 I) = STORE_downstream f2 mo2 mn2 (STORE_downstream f1 mo1 mn1 I)"
+proof -
+    have A1: "folderset (STORE_downstream f1 mo1 mn1 (STORE_downstream f2 mo2 mn2 I)) = folderset(STORE_downstream f2 mo2 mn2 (STORE_downstream f1 mo1 mn1 I))" by (simp add: store_folderset)
+
+    have A5: "\<forall> f . f1 \<noteq> f2 \<longrightarrow> filesystem (STORE_downstream f1 mo1 mn1 (STORE_downstream f2 mo2 mn2 I)) f = filesystem(STORE_downstream f2 mo2 mn2 (STORE_downstream f1 mo1 mn1 I)) f" by (smt STORE_downstream_def fun_upd_twist option.case_eq_if snd_conv store_filesystem)
+
+    have "f1 = f2 \<longrightarrow> filesystem (STORE_downstream f1 mo1 mn1 (STORE_downstream f2 mo2 mn2 I)) f1 = filesystem(STORE_downstream f2 mo2 mn2 (STORE_downstream f1 mo1 mn1 I)) f1"
+    proof auto
+        assume Ass: "f1 = f2"
+        hence "filesystem (STORE_downstream f1 mo1 mn1 (STORE_downstream f2 mo2 mn2 I)) f1 \<noteq> None" by (smt O2pre STORE_downstream_def fun_upd_eqD fun_upd_triv option.case_eq_if option.simps(3) snd_conv store_not_none)
+
+        hence "\<exists> y . filesystem (STORE_downstream f1 mo1 mn1 (STORE_downstream f2 mo2 mn2 I)) f1 = Some y" by simp
+        then obtain y where Ass4: "filesystem (STORE_downstream f1 mo1 mn1 (STORE_downstream f2 mo2 mn2 I)) f1 = Some y" by blast
+
+        have "\<exists> S . filesystem (I) f1 = Some S" by (metis O2pre STORE_atSource_def \<open>f1 = f2\<close> case_optionE msgLookup_def)
+        then obtain S where Ass2: "(filesystem I) f1 = Some S" by blast
+
+        have "\<exists> x . filesystem (STORE_downstream f2 mo2 mn2 I) f1 = Some x" using Ass by (metis O2pre option.collapse store_not_none)
+        then obtain x where Ass3: "filesystem (STORE_downstream f2 mo2 mn2 I) f1 = Some x" by blast
+
+        have "x = (S - {mo2}) \<union> {mn2}" using Ass Ass2 Ass3 unfolding STORE_downstream_def replaceMsg_def  by simp
+        hence Ass6: "y = (S - {mo1,mo2}) \<union> {mn1,mn2}" using Ass Ass2 Ass3 Ass4 O1pre O2pre unfolding STORE_downstream_def replaceMsg_def STORE_atSource_def by auto
+
+        have "\<exists> w . filesystem (STORE_downstream f1 mo1 mn1 I) f1 = Some w" using Ass by (metis O1pre option.collapse store_not_none)
+        then obtain w where Ass8: "filesystem (STORE_downstream f1 mo1 mn1 I) f1 = Some w" by blast
+
+        hence Ass9: "w = (S - {mo1}) \<union> {mn1}" using Ass Ass2 unfolding STORE_downstream_def replaceMsg_def by simp
+
+        have "filesystem(STORE_downstream f2 mo2 mn2 (STORE_downstream f1 mo1 mn1 I)) f1 \<noteq> None" using O1pre unfolding STORE_downstream_def using Ass Ass2 by auto
+
+        hence "\<exists> z . filesystem(STORE_downstream f2 mo2 mn2 (STORE_downstream f1 mo1 mn1 I)) f1 = Some z" by simp
+
+        then obtain z where Ass7: "filesystem(STORE_downstream f2 mo2 mn2 (STORE_downstream f1 mo1 mn1 I)) f1 = Some z" by blast
+
+        hence "z = (S - {mo1,mo2}) \<union> {mn1,mn2}" using Ass Ass2 Ass9 Ass8 O1pre O2pre unfolding STORE_downstream_def replaceMsg_def STORE_atSource_def by auto
+
+        thus "filesystem (STORE_downstream f2 mo1 mn1 (STORE_downstream f2 mo2 mn2 I)) f2 = filesystem (STORE_downstream f2 mo2 mn2 (STORE_downstream f2 mo1 mn1 I)) f2" using Ass7 Ass4 Ass6 Ass by auto
+    qed
+
+    thus ?thesis using A1 A5 by (smt O1pre O2pre STORE_downstream_def fun_upd_same fun_upd_twist fun_upd_upd option.case_eq_if prod_eqI snd_conv store_not_none)
+qed
+
+
+-- "Case 14"
 lemma commSTORE_EXPUNGE:
 fixes
-  I :: "('a, 'b) imap" and
-  f1 :: "'a" and
-  f2 :: "'a" and
-  m :: "'b" and
-  mo :: "'b" and
-  mn :: "'b"
-assumes 
-  O1pre: "EXPUNGE_atSource f1 m1 I" and
-  O2pre: "STORE_atSource f2 mo mn I"
+    I :: "('a, 'b) imap" and
+    f1 :: "'a" and
+    f2 :: "'a" and
+    m :: "'b" and
+    mo :: "'b" and
+    mn :: "'b"
+assumes
+    O1pre: "EXPUNGE_atSource f1 m1 I" and
+    O2pre: "STORE_atSource f2 mo mn I"
 shows "EXPUNGE_downstream f1 m1 (STORE_downstream f2 mo mn I) = STORE_downstream f2 mo mn (EXPUNGE_downstream f1 m1 I)"
 proof -
-  have A1: "folderset (EXPUNGE_downstream f1 m1 (STORE_downstream f2 mo mn I)) = folderset (STORE_downstream f2 mo mn (EXPUNGE_downstream f1 m1 I))"
-    unfolding EXPUNGE_downstream_def STORE_downstream_def by simp
-  have A2: "\<forall> f . f1 \<noteq> f2 \<longrightarrow> filesystem (EXPUNGE_downstream f1 m1 (STORE_downstream f2 mo mn I)) f = filesystem (STORE_downstream f2 mo mn (EXPUNGE_downstream f1 m1 I)) f"
-    using O1pre O2pre unfolding EXPUNGE_downstream_def EXPUNGE_atSource_def STORE_downstream_def STORE_atSource_def 
-    by (smt fun_upd_other fun_upd_twist option.case_eq_if snd_conv)
-  have A3: "\<forall> f . (f1 = f2 \<and> f \<noteq> f1) \<longrightarrow> filesystem (EXPUNGE_downstream f1 m1 (STORE_downstream f2 mo mn I)) f = filesystem (STORE_downstream f2 mo mn (EXPUNGE_downstream f1 m1 I)) f"
-    using O1pre O2pre unfolding EXPUNGE_downstream_def EXPUNGE_atSource_def STORE_downstream_def STORE_atSource_def 
-    by (smt fun_upd_other fun_upd_twist option.case_eq_if snd_conv)
-  have "f1 = f2 \<longrightarrow> filesystem (EXPUNGE_downstream f1 m1 (STORE_downstream f2 mo mn I)) f1 = filesystem (STORE_downstream f2 mo mn (EXPUNGE_downstream f1 m1 I)) f1"
-    using O1pre O2pre unfolding EXPUNGE_downstream_def EXPUNGE_atSource_def STORE_downstream_def STORE_atSource_def msgLookup_def replaceMsg_def 
-    by (smt Diff_empty Diff_insert Diff_insert0 Un_Diff empty_iff fun_upd_same insertE insert_commute map_upd_eqD1 option.case_eq_if option.collapse option.simps(3) snd_conv)
+    have A1: "folderset (EXPUNGE_downstream f1 m1 (STORE_downstream f2 mo mn I)) = folderset (STORE_downstream f2 mo mn (EXPUNGE_downstream f1 m1 I))" unfolding EXPUNGE_downstream_def STORE_downstream_def by simp
 
-  hence "filesystem (EXPUNGE_downstream f1 m1 (STORE_downstream f2 mo mn I)) = filesystem (STORE_downstream f2 mo mn (EXPUNGE_downstream f1 m1 I))"
-    using O1pre O2pre A2 A3 unfolding EXPUNGE_downstream_def EXPUNGE_atSource_def STORE_downstream_def STORE_atSource_def by fastforce      
-      
-	thus ?thesis using A1 prod_eqI by blast
+    have A2: "\<forall> f . f1 \<noteq> f2 \<longrightarrow> filesystem (EXPUNGE_downstream f1 m1 (STORE_downstream f2 mo mn I)) f = filesystem (STORE_downstream f2 mo mn (EXPUNGE_downstream f1 m1 I)) f" using O1pre O2pre unfolding EXPUNGE_downstream_def EXPUNGE_atSource_def STORE_downstream_def STORE_atSource_def by (smt fun_upd_other fun_upd_twist option.case_eq_if snd_conv)
+
+    have A3: "\<forall> f . (f1 = f2 \<and> f \<noteq> f1) \<longrightarrow> filesystem (EXPUNGE_downstream f1 m1 (STORE_downstream f2 mo mn I)) f = filesystem (STORE_downstream f2 mo mn (EXPUNGE_downstream f1 m1 I)) f" using O1pre O2pre unfolding EXPUNGE_downstream_def EXPUNGE_atSource_def STORE_downstream_def STORE_atSource_def by (smt fun_upd_other fun_upd_twist option.case_eq_if snd_conv)
+
+    have "f1 = f2 \<longrightarrow> filesystem (EXPUNGE_downstream f1 m1 (STORE_downstream f2 mo mn I)) f1 = filesystem (STORE_downstream f2 mo mn (EXPUNGE_downstream f1 m1 I)) f1" using O1pre O2pre unfolding EXPUNGE_downstream_def EXPUNGE_atSource_def STORE_downstream_def STORE_atSource_def msgLookup_def replaceMsg_def by (smt Diff_empty Diff_insert Diff_insert0 Un_Diff empty_iff fun_upd_same insertE insert_commute map_upd_eqD1 option.case_eq_if option.collapse option.simps(3) snd_conv)
+
+    hence "filesystem (EXPUNGE_downstream f1 m1 (STORE_downstream f2 mo mn I)) = filesystem (STORE_downstream f2 mo mn (EXPUNGE_downstream f1 m1 I))" using O1pre O2pre A2 A3 unfolding EXPUNGE_downstream_def EXPUNGE_atSource_def STORE_downstream_def STORE_atSource_def by fastforce
+
+    thus ?thesis using A1 prod_eqI by blast
 qed
-  
--- "######## END COMMUTATIVITY #########"  
-  
+
+
+-- "Case 15"
+lemma commEXPUNGE:
+fixes
+    I :: "('a, 'b) imap" and
+    f1 :: "'a" and
+    f2 :: "'a" and
+    m1 :: "'b" and
+    m2 :: "'b"
+assumes
+    O1pre: " EXPUNGE_atSource f1 m1 I" and
+    O2pre: " EXPUNGE_atSource f2 m2 I"
+shows "EXPUNGE_downstream f1 m1 (EXPUNGE_downstream f2 m2 I) = EXPUNGE_downstream f2 m2 (EXPUNGE_downstream f1 m1 I)"
+proof -
+    have A1: "folderset (EXPUNGE_downstream f1 m1 (EXPUNGE_downstream f2 m2 I)) = folderset (EXPUNGE_downstream f2 m2 (EXPUNGE_downstream f1 m1 I))" unfolding EXPUNGE_downstream_def EXPUNGE_atSource_def by simp
+
+    have "filesystem (EXPUNGE_downstream f1 m1 (EXPUNGE_downstream f2 m2 I)) = filesystem (EXPUNGE_downstream f2 m2 (EXPUNGE_downstream f1 m1 I))" using O1pre O2pre unfolding EXPUNGE_downstream_def EXPUNGE_atSource_def msgLookup_def by (smt Diff_insert fun_upd_twist fun_upd_upd insert_commute map_upd_Some_unfold option.case_eq_if option.collapse option.simps(3) snd_conv)
+
+    thus ?thesis using A1 by (simp add: prod_eqI)
+qed
+
+
+
 end
-	

--- a/Isabelle/ORSet.thy
+++ b/Isabelle/ORSet.thy
@@ -1,30 +1,30 @@
 theory ORSet
 imports Main
-    
+
 begin
 
 type_synonym 'a orset = "('a \<times> nat) set"
-	
+
 definition abstractState ::
   "'a orset \<Rightarrow> 'a set"
 where
   "abstractState S = {e . (\<exists> n . (e,n) \<in> S)}"
-  
+
 definition fresh ::
   "nat \<Rightarrow> 'a orset \<Rightarrow> bool"
 where
   "fresh n S = (\<nexists> e . (e,n) \<in> S)"
-  
+
 definition lookup ::
   "'a \<Rightarrow> 'a orset \<Rightarrow> bool"
 where
-  "lookup e S = (\<exists> n. (e,n) \<in> S)" 
+  "lookup e S = (\<exists> n. (e,n) \<in> S)"
 
 definition add ::
   "'element \<Rightarrow> nat \<Rightarrow> 'element orset \<Rightarrow> 'element orset"
 where
   "add e alpha S = S \<union> {(e, alpha)}"
-  
+
 definition remove_atSource ::
 	"'element \<Rightarrow> 'element orset \<Rightarrow> 'element orset"
 	where
@@ -33,7 +33,7 @@ definition remove_atSource ::
 definition remove_downstream ::
   "'element orset \<Rightarrow> 'element orset \<Rightarrow> 'element orset"
 where
-  "remove_downstream R S = S - R"  
+  "remove_downstream R S = S - R"
 
 lemma commAdd:
   shows "\<forall> S . n1 \<noteq> n2 \<longrightarrow> add e1 n1 (add e2 n2 S) = add e2 n2 (add e1 n1 S)"
@@ -43,7 +43,7 @@ proof clarify
   then show "add e1 n1 (add e2 n2 S) = add e2 n2 (add e1 n1 S)"
     by (simp add: Un_commute add_def)
 qed
-	
+
 lemma commRemove:
 fixes
   S :: "'a orset" and
@@ -51,7 +51,7 @@ fixes
   R2 :: "'a orset" and
   e1 :: "'a" and
   e2 :: "'a"
-assumes 
+assumes
   O1R1: " R1 = remove_atSource e1 S" and
   O2R2: " R2 = remove_atSource e2 S"
 shows "remove_downstream R2 (remove_downstream R1 S) = remove_downstream R1 (remove_downstream R2 S)"
@@ -75,4 +75,4 @@ proof -
 qed
 
 end
- 
+

--- a/Isabelle/ORSet.thy
+++ b/Isabelle/ORSet.thy
@@ -3,76 +3,104 @@ imports Main
 
 begin
 
+
+
+-- "#############################"
+-- "### Definitions & Helpers ###"
+-- "#############################"
+
+
 type_synonym 'a orset = "('a \<times> nat) set"
 
+
 definition abstractState ::
-  "'a orset \<Rightarrow> 'a set"
+    "'a orset \<Rightarrow> 'a set"
 where
-  "abstractState S = {e . (\<exists> n . (e,n) \<in> S)}"
+    "abstractState S = {e . (\<exists> n . (e, n) \<in> S)}"
+
 
 definition fresh ::
-  "nat \<Rightarrow> 'a orset \<Rightarrow> bool"
+    "nat \<Rightarrow> 'a orset \<Rightarrow> bool"
 where
-  "fresh n S = (\<nexists> e . (e,n) \<in> S)"
+    "fresh n S = (\<nexists> e . (e, n) \<in> S)"
+
 
 definition lookup ::
-  "'a \<Rightarrow> 'a orset \<Rightarrow> bool"
+    "'a \<Rightarrow> 'a orset \<Rightarrow> bool"
 where
-  "lookup e S = (\<exists> n. (e,n) \<in> S)"
+    "lookup e S = (\<exists> n. (e, n) \<in> S)"
+
 
 definition add ::
-  "'element \<Rightarrow> nat \<Rightarrow> 'element orset \<Rightarrow> 'element orset"
+    "'element \<Rightarrow> nat \<Rightarrow> 'element orset \<Rightarrow> 'element orset"
 where
-  "add e alpha S = S \<union> {(e, alpha)}"
+    "add e alpha S = S \<union> {(e, alpha)}"
+
 
 definition remove_atSource ::
-	"'element \<Rightarrow> 'element orset \<Rightarrow> 'element orset"
-	where
-		"remove_atSource e S = {(a,b) \<in> S. a = e}"
+    "'element \<Rightarrow> 'element orset \<Rightarrow> 'element orset"
+where
+    "remove_atSource e S = {(a, b) \<in> S. a = e}"
 
 definition remove_downstream ::
-  "'element orset \<Rightarrow> 'element orset \<Rightarrow> 'element orset"
+    "'element orset \<Rightarrow> 'element orset \<Rightarrow> 'element orset"
 where
-  "remove_downstream R S = S - R"
+    "remove_downstream R S = S - R"
+
+
+
+-- "#################################################"
+-- "### Commutativity Proofs of OR-Set Operations ###"
+-- "#################################################"
+
 
 lemma commAdd:
-  shows "\<forall> S . n1 \<noteq> n2 \<longrightarrow> add e1 n1 (add e2 n2 S) = add e2 n2 (add e1 n1 S)"
+    shows "\<forall> S . n1 \<noteq> n2 \<longrightarrow> add e1 n1 (add e2 n2 S) = add e2 n2 (add e1 n1 S)"
 proof clarify
-  fix S
-  assume "n1 \<noteq> n2"
-  then show "add e1 n1 (add e2 n2 S) = add e2 n2 (add e1 n1 S)"
+    fix S
+    assume "n1 \<noteq> n2"
+    then show "add e1 n1 (add e2 n2 S) = add e2 n2 (add e1 n1 S)"
     by (simp add: Un_commute add_def)
 qed
 
+
 lemma commRemove:
 fixes
-  S :: "'a orset" and
-  R1 :: "'a orset" and
-  R2 :: "'a orset" and
-  e1 :: "'a" and
-  e2 :: "'a"
+    S :: "'a orset" and
+    R1 :: "'a orset" and
+    R2 :: "'a orset" and
+    e1 :: "'a" and
+    e2 :: "'a"
 assumes
-  O1R1: " R1 = remove_atSource e1 S" and
-  O2R2: " R2 = remove_atSource e2 S"
+    O1R1: " R1 = remove_atSource e1 S" and
+    O2R2: " R2 = remove_atSource e2 S"
 shows "remove_downstream R2 (remove_downstream R1 S) = remove_downstream R1 (remove_downstream R2 S)"
 proof -
-	show ?thesis using O1R1 O2R2 unfolding remove_atSource_def remove_downstream_def by auto
+    show ?thesis
+    using O1R1 O2R2
+    unfolding remove_atSource_def remove_downstream_def
+    by auto
 qed
+
 
 lemma commAddRemove:
 fixes
-  S :: "'a orset" and
-  R :: "'a orset" and
-  e1 :: "'a" and
-  e2 :: "'a" and
-  n :: nat
+    S :: "'a orset" and
+    R :: "'a orset" and
+    e1 :: "'a" and
+    e2 :: "'a" and
+    n :: nat
 assumes
-	OR: " R = remove_atSource e1 S" and
-	freshn: "fresh n S"
+    OR: " R = remove_atSource e1 S" and
+    freshn: "fresh n S"
 shows "abstractState (remove_downstream R (add e2 n S)) = abstractState (add e2 n (remove_downstream R S))"
 proof -
-  show ?thesis using OR freshn unfolding abstractState_def remove_downstream_def remove_atSource_def add_def fresh_def by auto
+    show ?thesis
+    using OR freshn
+    unfolding abstractState_def remove_downstream_def remove_atSource_def add_def fresh_def
+    by auto
 qed
 
-end
 
+
+end


### PR DESCRIPTION
I tried to unify namings, looks, and indentations of Isabelle/HOL code for verifying pluto. In my opinion, this is already more nicely readable, although some convention on line breaks of very long statements might still be needed.

As far as I could see, Isabelle is still able to achieve all subgoals.